### PR TITLE
Update governance with voting/proxy/non-voting maintainers

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -2,7 +2,13 @@
 
 ## Project Maintainers
 
-[Project maintainers](MAINTAINERS.md) are responsible for activities around maintaining and updating the papiNet API standard. Final decisions on the standard reside with the project maintainers.
+[Project maintainers](MAINTAINERS.md) are responsible for activities around maintaining and updating the papiNet API standard. There are three types of project maintainers:
+
+* Voting maintainer, who have 1 vote, and may designate up to one proxy maintainer;
+* Proxy maintainer, who have 1 vote only if the voting maintainer by who she/he has been designated as proxy maintainer is absent;
+* Non-voting maintainer, who does not participate in voting.
+
+While all maintainers should equally participate in the development of the papiNet API standard, final decisions on the standard reside with the project voting maintainers and proxy maintainers.
 
 Maintainers MUST remain active. If they are unresponsive for >6 months, they will be automatically removed unless a [two-thirds supermajority vote](https://en.wikipedia.org/wiki/Supermajority#Two-thirds_vote) of the other project maintainers agrees to extend the period to be greater than 6 months.
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -11,7 +11,7 @@
 
 ## Proxy Maintainer
 
-* Matthew Oberpriller, proxy of Marcel Dumont [@globaltopmedia](https://github.com/globaltopmedia)
+* Matthew Oberpriller [@maoberpriller](https://github.com/maoberpriller), proxy of Marcel Dumont [@globaltopmedia](https://github.com/globaltopmedia)
 
 ## Non-Voting Maintainer
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,7 +1,22 @@
-## Active
-* Patrice Krakow [@patricekrakow](https://github.com/patricekrakow)
-* Lars Olofsson [@larsolofsson](https://github.com/larsolofsson)
-* Bengt Wentus [@bengtwentus](https://github.com/bengtwentus)
+## Voting Maintainers
+
 * Al Ivan [@robertalivan](https://github.com/robertalivan)
+* Bengt Wentus [@bengtwentus](https://github.com/bengtwentus)
+* Björn Jonsson Dannetun [@bjdannetun](https://github.com/bjdannetun)
 * Jens Nordenberg [@MrNordenberg](https://github.com/MrNordenberg)
+* Lars Olofsson [@larsolofsson](https://github.com/larsolofsson)
+* Marcel Dumont [@globaltopmedia](https://github.com/globaltopmedia)
+* Per Hammarström [@t02phf](https://github.com/t02phf)
+* Tom Meniga [@tommeniga](https://github.com/tommeniga)
+
+## Proxy Maintainer
+
+* Matthew Oberpriller, proxy of Marcel Dumont [@globaltopmedia](https://github.com/globaltopmedia)
+
+## Non-Voting Maintainer
+
+* Patrice Krakow [@patricekrakow](https://github.com/patricekrakow)
+
+## Non-Active Maintainer
+
 * Jakub Gaj [@jakubgaj-ip](https://github.com/jakubgaj-ip)

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -5,13 +5,13 @@
 * Björn Jonsson Dannetun [@bjdannetun](https://github.com/bjdannetun)
 * Jens Nordenberg [@MrNordenberg](https://github.com/MrNordenberg)
 * Lars Olofsson [@larsolofsson](https://github.com/larsolofsson)
-* Marcel Dumont [@globaltopmedia](https://github.com/globaltopmedia)
+* Matthew Oberpriller [@maoberpriller](https://github.com/maoberpriller)
 * Per Hammarström [@t02phf](https://github.com/t02phf)
 * Tom Meniga [@tommeniga](https://github.com/tommeniga)
 
 ## Proxy Maintainer
 
-* Matthew Oberpriller [@maoberpriller](https://github.com/maoberpriller), proxy of Marcel Dumont [@globaltopmedia](https://github.com/globaltopmedia)
+* Marcel Dumont [@globaltopmedia](https://github.com/globaltopmedia), proxy of Matthew Oberpriller [@maoberpriller](https://github.com/maoberpriller)
 
 ## Non-Voting Maintainer
 


### PR DESCRIPTION
As discussed, I have updated our governance with the notion of proxy. I have also added Marcel to the list of "voting maintainer" and Matt - for who I am missing a GitHub account - to the list of "non-voting maintainer".