### PR TITLE
Update papiNet-API.yaml

### DIFF
--- a/1.0.0/papiNet-API.yaml
+++ b/1.0.0/papiNet-API.yaml
@@ -147,7 +147,7 @@ components:
           type: string
           format: uuid
         orderLineItemNumber:
-          type: number
+          type: integer
           minimum: 0
         orderLineItemStatus:
           type: string


### PR DESCRIPTION
Changed type of orderLineItemNumber from number to integer.
This is not a backward compatibel change, is it?