### PR TITLE
Update order-status.md

### DIFF
--- a/1.1.0/order-status.md
+++ b/1.1.0/order-status.md
@@ -139,7 +139,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "e436266b-d831-47a1-9fef-3f749c955673",
-      "orderLineItemNumber": "1",
+      "orderLineItemNumber": 1,
       "orderLineItemStatus": "Pending",
       "changeable": true,
       "quantities": [
@@ -187,7 +187,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "e436266b-d831-47a1-9fef-3f749c955673",
-      "orderLineItemNumber": "1",
+      "orderLineItemNumber": 1,
       "orderLineItemStatus": "Confirmed",
       "changeable": true,
       "quantities": [
@@ -247,7 +247,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "fc890c7d-39e5-4181-8040-affde22edf89",
-      "orderLineItemNumber": "1",
+      "orderLineItemNumber": 1,
       "orderLineItemStatus": "Confirmed",
       "changeable": false,
       "quantities": [
@@ -307,7 +307,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "e436266b-d831-47a1-9fef-3f749c955673",
-      "orderLineItemNumber": "1",
+      "orderLineItemNumber": 1,
       "orderLineItemStatus": "ProductionCompleted",
       "changeable": false,
       "quantities": [
@@ -379,7 +379,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "e436266b-d831-47a1-9fef-3f749c955673",
-      "orderLineItemNumber": "1",
+      "orderLineItemNumber": 1,
       "orderLineItemStatus": "ShipmentCompleted",
       "changeable": false,
       "quantities": [
@@ -463,7 +463,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "e436266b-d831-47a1-9fef-3f749c955673",
-      "orderLineItemNumber": "1",
+      "orderLineItemNumber": 1,
       "orderLineItemStatus": "Completed",
       "changeable": false,
       "quantities": [
@@ -606,7 +606,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "6a0d16db-546f-4c19-b288-ddd2a250f064",
-      "orderLineItemNumber": "1",
+      "orderLineItemNumber": 1,
       "orderLineItemStatus": "Pending",
       "changeable": true,
       "quantities": [
@@ -654,7 +654,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "6a0d16db-546f-4c19-b288-ddd2a250f064",
-      "orderLineItemNumber": "1",
+      "orderLineItemNumber": 1,
       "orderLineItemStatus": "Confirmed",
       "changeable": true,
       "quantities": [
@@ -714,7 +714,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "6a0d16db-546f-4c19-b288-ddd2a250f064",
-      "orderLineItemNumber": "1",
+      "orderLineItemNumber": 1,
       "orderLineItemStatus": "Confirmed",
       "changeable": false,
       "quantities": [
@@ -774,7 +774,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "6a0d16db-546f-4c19-b288-ddd2a250f064",
-      "orderLineItemNumber": "1",
+      "orderLineItemNumber": 1,
       "orderLineItemStatus": "Confirmed",
       "changeable": false,
       "quantities": [
@@ -846,7 +846,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "6a0d16db-546f-4c19-b288-ddd2a250f064",
-      "orderLineItemNumber": "1",
+      "orderLineItemNumber": 1,
       "orderLineItemStatus": "Confirmed",
       "changeable": false,
       "quantities": [
@@ -918,7 +918,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "6a0d16db-546f-4c19-b288-ddd2a250f064",
-      "orderLineItemNumber": "1",
+      "orderLineItemNumber": 1,
       "orderLineItemStatus": "ProductionCompleted",
       "changeable": false,
       "quantities": [
@@ -990,7 +990,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "6a0d16db-546f-4c19-b288-ddd2a250f064",
-      "orderLineItemNumber": "1",
+      "orderLineItemNumber": 1,
       "orderLineItemStatus": "ShipmentCompleted",
       "changeable": false,
       "quantities": [
@@ -1074,7 +1074,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "6a0d16db-546f-4c19-b288-ddd2a250f064",
-      "orderLineItemNumber": "1",
+      "orderLineItemNumber": 1,
       "orderLineItemStatus": "Completed",
       "changeable": false,
       "quantities": [
@@ -1262,7 +1262,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "29868f71-46a0-4757-981e-1ad26a4cb3c1",
-      "orderLineItemNumber": "1",
+      "orderLineItemNumber": 1,
       "orderLineItemStatus": "Pending",
       "changeable": true,
       "quantities": [
@@ -1310,7 +1310,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "29868f71-46a0-4757-981e-1ad26a4cb3c1",
-      "orderLineItemNumber": "1",
+      "orderLineItemNumber": 1,
       "orderLineItemStatus": "Confirmed",
       "changeable": true,
       "quantities": [
@@ -1370,7 +1370,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "29868f71-46a0-4757-981e-1ad26a4cb3c1",
-      "orderLineItemNumber": "1",
+      "orderLineItemNumber": 1,
       "orderLineItemStatus": "Confirmed",
       "changeable": false,
       "quantities": [
@@ -1430,7 +1430,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "29868f71-46a0-4757-981e-1ad26a4cb3c1",
-      "orderLineItemNumber": "1",
+      "orderLineItemNumber": 1,
       "orderLineItemStatus": "ProductionCompleted",
       "changeable": false,
       "quantities": [
@@ -1502,7 +1502,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "29868f71-46a0-4757-981e-1ad26a4cb3c1",
-      "orderLineItemNumber": "1",
+      "orderLineItemNumber": 1,
       "orderLineItemStatus": "ProductionCompleted",
       "changeable": false,
       "quantities": [
@@ -1586,7 +1586,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "29868f71-46a0-4757-981e-1ad26a4cb3c1",
-      "orderLineItemNumber": "1",
+      "orderLineItemNumber": 1,
       "orderLineItemStatus": "ShipmentCompleted",
       "changeable": false,
       "quantities": [
@@ -1670,7 +1670,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "29868f71-46a0-4757-981e-1ad26a4cb3c1",
-      "orderLineItemNumber": "1",
+      "orderLineItemNumber": 1,
       "orderLineItemStatus": "Completed",
       "changeable": false,
       "quantities": [
@@ -1762,7 +1762,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "1c9192cb-10d4-4e2e-a3d0-bcb4d67eb605",
-      "orderLineItemNumber": "1",
+      "orderLineItemNumber": 1,
       "orderLineItemStatus": "Pending",
       "changeable": true,
       "quantities": [
@@ -1810,7 +1810,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "1c9192cb-10d4-4e2e-a3d0-bcb4d67eb605",
-      "orderLineItemNumber": "1",
+      "orderLineItemNumber": 1,
       "orderLineItemStatus": "Confirmed",
       "changeable": true,
       "quantities": [
@@ -1870,7 +1870,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "1c9192cb-10d4-4e2e-a3d0-bcb4d67eb605",
-      "orderLineItemNumber": "1",
+      "orderLineItemNumber": 1,
       "orderLineItemStatus": "Confirmed",
       "changeable": false,
       "quantities": [
@@ -1930,7 +1930,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "1c9192cb-10d4-4e2e-a3d0-bcb4d67eb605",
-      "orderLineItemNumber": "1",
+      "orderLineItemNumber": 1,
       "orderLineItemStatus": "Confirmed",
       "changeable": false,
       "quantities": [
@@ -2002,7 +2002,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "1c9192cb-10d4-4e2e-a3d0-bcb4d67eb605",
-      "orderLineItemNumber": "1",
+      "orderLineItemNumber": 1,
       "orderLineItemStatus": "Confirmed",
       "changeable": false,
       "quantities": [
@@ -2086,7 +2086,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "1c9192cb-10d4-4e2e-a3d0-bcb4d67eb605",
-      "orderLineItemNumber": "1",
+      "orderLineItemNumber": 1,
       "orderLineItemStatus": "ProductionCompleted",
       "changeable": false,
       "quantities": [
@@ -2170,7 +2170,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "1c9192cb-10d4-4e2e-a3d0-bcb4d67eb605",
-      "orderLineItemNumber": "1",
+      "orderLineItemNumber": 1,
       "orderLineItemStatus": "ProductionCompleted",
       "changeable": false,
       "quantities": [
@@ -2254,7 +2254,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "1c9192cb-10d4-4e2e-a3d0-bcb4d67eb605",
-      "orderLineItemNumber": "1",
+      "orderLineItemNumber": 1,
       "orderLineItemStatus": "ShipmentCompleted",
       "changeable": false,
       "quantities": [
@@ -2338,7 +2338,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "1c9192cb-10d4-4e2e-a3d0-bcb4d67eb605",
-      "orderLineItemNumber": "1",
+      "orderLineItemNumber": 1,
       "orderLineItemStatus": "Completed",
       "changeable": false,
       "quantities": [
@@ -2430,7 +2430,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "1deca55f-2d03-4c18-93d0-c60362b891a5",
-      "orderLineItemNumber": "1",
+      "orderLineItemNumber": 1,
       "orderLineItemStatus": "Pending",
       "changeable": true,
       "quantities": [
@@ -2478,7 +2478,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "1deca55f-2d03-4c18-93d0-c60362b891a5",
-      "orderLineItemNumber": "1",
+      "orderLineItemNumber": 1,
       "orderLineItemStatus": "Confirmed",
       "changeable": true,
       "quantities": [
@@ -2538,7 +2538,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "1deca55f-2d03-4c18-93d0-c60362b891a5",
-      "orderLineItemNumber": "1",
+      "orderLineItemNumber": 1,
       "orderLineItemStatus": "Confirmed",
       "changeable": false,
       "quantities": [
@@ -2598,7 +2598,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "1deca55f-2d03-4c18-93d0-c60362b891a5",
-      "orderLineItemNumber": "1",
+      "orderLineItemNumber": 1,
       "orderLineItemStatus": "ProductionCompleted",
       "changeable": false,
       "quantities": [
@@ -2670,7 +2670,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "1deca55f-2d03-4c18-93d0-c60362b891a5",
-      "orderLineItemNumber": "1",
+      "orderLineItemNumber": 1,
       "orderLineItemStatus": "ShipmentCompleted",
       "changeable": false,
       "quantities": [
@@ -2754,7 +2754,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "1deca55f-2d03-4c18-93d0-c60362b891a5",
-      "orderLineItemNumber": "1",
+      "orderLineItemNumber": 1,
       "orderLineItemStatus": "Completed",
       "changeable": false,
       "quantities": [

--- a/1.1.0/order-status.md
+++ b/1.1.0/order-status.md
@@ -52,8 +52,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
 * Scenario B - Multiple Productions and One Shipment
 * Scenario C - One Production and Multiple Shipments
 * Scenario D - Multiple Productions and Multiple Shipments
-* Scenario E - Under Shipment
-* Scenario F - Over Shipment
+* Scenario E - Under Shipment 
 
 ### Scenario A - One Production and One Shipment
 
@@ -106,7 +105,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
 }
 ```
 
-> You can see that the _Order Issuer_ has **5**  _Active orders_. The response only contains the header information, to get the details of the order, including the order lines, you can see the `link` properties that contains a prepared API endpoint giving direct access to the full order. You can also notice that the response only gives 2 _Active orders_ out of the 6. This is because of the pagination mechanism.
+> You can see that the _Order Issuer_ has **6**  _Active orders_. The response only contains the header information, to get the details of the order, including the order lines, you can see the `link` properties that contains a prepared API endpoint giving direct access to the full order. You can also notice that the response only gives 2 _Active orders_ out of the 6. This is because of the pagination mechanism.
 
 We have prepared the scenario A on the order `1001`.
 
@@ -140,7 +139,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "e436266b-d831-47a1-9fef-3f749c955673",
-      "orderLineItemNumber": 1,
+      "orderLineItemNumber": "1",
       "orderLineItemStatus": "Pending",
       "changeable": true,
       "quantities": [
@@ -188,7 +187,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "e436266b-d831-47a1-9fef-3f749c955673",
-      "orderLineItemNumber": 1,
+      "orderLineItemNumber": "1",
       "orderLineItemStatus": "Confirmed",
       "changeable": true,
       "quantities": [
@@ -221,7 +220,7 @@ It shows that the first (and unique) line is now `Confirmed`, but can still be c
 
 #### Step 3 of Scenario A
 
-The step 3 of the scenario A will simulate the situation in which the _Supplier_ has started the production (or conversion) process for the order line, meaning that it can't be changed anymore (`"changeable": true`). Then, the _Order Issuer_ sends another similar API request to the _Supplier_ in order to get the details of the first order `6a0d16db-546f-4c19-b288-ddd2a250f064`:
+The step 3 of the scenario A will simulate the situation in which the _Supplier_ has started the production (or conversion) process for the order line, meaning that it can't be changed anymore (`"changeable": false`). Then, the _Order Issuer_ sends another similar API request to the _Supplier_ in order to get the details of the first order `6a0d16db-546f-4c19-b288-ddd2a250f064`:
 
 ```text
 $ curl --request GET \
@@ -248,7 +247,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "fc890c7d-39e5-4181-8040-affde22edf89",
-      "orderLineItemNumber": 1,
+      "orderLineItemNumber": "1",
       "orderLineItemStatus": "Confirmed",
       "changeable": false,
       "quantities": [
@@ -277,7 +276,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
 }
 ```
 
-It shows that the first (and unique) line is still `Confirmed`, but cannot be changed anymore (`"changeable": true`).
+It shows that the first (and unique) line is still `Confirmed`, but cannot be changed anymore (`"changeable": false`).
 
 #### Step 4 of Scenario A
 
@@ -308,7 +307,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "e436266b-d831-47a1-9fef-3f749c955673",
-      "orderLineItemNumber": 1,
+      "orderLineItemNumber": "1",
       "orderLineItemStatus": "ProductionCompleted",
       "changeable": false,
       "quantities": [
@@ -380,7 +379,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "e436266b-d831-47a1-9fef-3f749c955673",
-      "orderLineItemNumber": 1,
+      "orderLineItemNumber": "1",
       "orderLineItemStatus": "ShipmentCompleted",
       "changeable": false,
       "quantities": [
@@ -464,7 +463,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "e436266b-d831-47a1-9fef-3f749c955673",
-      "orderLineItemNumber": 1,
+      "orderLineItemNumber": "1",
       "orderLineItemStatus": "Completed",
       "changeable": false,
       "quantities": [
@@ -523,7 +522,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
 }
 ```
 
-It shows that the first (and unique) line, as well as the order `1001`, has now reached the status `Completed`. The quantities have been updated accordingly, using the context `Invoiced`. Notice that only the quantity of type `Count` is not relevant in the context `Invoiced`. The quantities have been updated accordingly, using the context `Invoiced`. Notice that only the quantity of type `Count` is not relevant in the context `Invoiced`.
+It shows that the first (and unique) line, as well as the order `1001`, has now reached the status `Completed`. The quantities have been updated accordingly, using the context `Invoiced`. Notice that only the quantity of type `Count` is not relevant in the context `Invoiced`.
 
 ### Scenario B - Multiple Productions and One Shipment
 
@@ -575,7 +574,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
 }
 ```
 
-We have prepared the scenario A on the order `1002`.
+We have prepared the scenario B on the order `1002`.
 
 #### Step 1 of Scenario B
 
@@ -607,7 +606,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "6a0d16db-546f-4c19-b288-ddd2a250f064",
-      "orderLineItemNumber": 1,
+      "orderLineItemNumber": "1",
       "orderLineItemStatus": "Pending",
       "changeable": true,
       "quantities": [
@@ -655,7 +654,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "6a0d16db-546f-4c19-b288-ddd2a250f064",
-      "orderLineItemNumber": 1,
+      "orderLineItemNumber": "1",
       "orderLineItemStatus": "Confirmed",
       "changeable": true,
       "quantities": [
@@ -688,7 +687,7 @@ It shows that the first (and unique) line is now `Confirmed`, but can still be c
 
 #### Step 3 of Scenario B
 
-The step 3 of the scenario B will simulate the situation in which the _Supplier_ has started the production (or conversion) process for the order line, meaning that it can't be changed anymore (`"changeable": true`). Then, the _Order Issuer_ sends an API request to the _Supplier_ in order to get the details of the second order `778fe5cb-f7ac-4493-b492-25fe98df67c4`:
+The step 3 of the scenario B will simulate the situation in which the _Supplier_ has started the production (or conversion) process for the order line, meaning that it can't be changed anymore (`"changeable": false`). Then, the _Order Issuer_ sends an API request to the _Supplier_ in order to get the details of the second order `778fe5cb-f7ac-4493-b492-25fe98df67c4`:
 
 ```text
 $ curl --request GET \
@@ -715,7 +714,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "6a0d16db-546f-4c19-b288-ddd2a250f064",
-      "orderLineItemNumber": 1,
+      "orderLineItemNumber": "1",
       "orderLineItemStatus": "Confirmed",
       "changeable": false,
       "quantities": [
@@ -744,7 +743,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
 }
 ```
 
-It shows that the first (and unique) line is still `Confirmed`, but cannot be changed anymore (`"changeable": true`).
+It shows that the first (and unique) line is still `Confirmed`, but cannot be changed anymore (`"changeable": false`).
 
 #### Step 4 of Scenario B
 
@@ -775,7 +774,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "6a0d16db-546f-4c19-b288-ddd2a250f064",
-      "orderLineItemNumber": 1,
+      "orderLineItemNumber": "1",
       "orderLineItemStatus": "Confirmed",
       "changeable": false,
       "quantities": [
@@ -847,7 +846,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "6a0d16db-546f-4c19-b288-ddd2a250f064",
-      "orderLineItemNumber": 1,
+      "orderLineItemNumber": "1",
       "orderLineItemStatus": "Confirmed",
       "changeable": false,
       "quantities": [
@@ -919,7 +918,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "6a0d16db-546f-4c19-b288-ddd2a250f064",
-      "orderLineItemNumber": 1,
+      "orderLineItemNumber": "1",
       "orderLineItemStatus": "ProductionCompleted",
       "changeable": false,
       "quantities": [
@@ -991,7 +990,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "6a0d16db-546f-4c19-b288-ddd2a250f064",
-      "orderLineItemNumber": 1,
+      "orderLineItemNumber": "1",
       "orderLineItemStatus": "ShipmentCompleted",
       "changeable": false,
       "quantities": [
@@ -1075,7 +1074,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "6a0d16db-546f-4c19-b288-ddd2a250f064",
-      "orderLineItemNumber": 1,
+      "orderLineItemNumber": "1",
       "orderLineItemStatus": "Completed",
       "changeable": false,
       "quantities": [
@@ -1263,7 +1262,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "29868f71-46a0-4757-981e-1ad26a4cb3c1",
-      "orderLineItemNumber": 1,
+      "orderLineItemNumber": "1",
       "orderLineItemStatus": "Pending",
       "changeable": true,
       "quantities": [
@@ -1311,7 +1310,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "29868f71-46a0-4757-981e-1ad26a4cb3c1",
-      "orderLineItemNumber": 1,
+      "orderLineItemNumber": "1",
       "orderLineItemStatus": "Confirmed",
       "changeable": true,
       "quantities": [
@@ -1344,7 +1343,7 @@ It shows that the first (and unique) line is now `Confirmed`, but can still be c
 
 #### Step 3 of Scenario C
 
-The step 3 of the scenario C will simulate the situation in which the _Supplier_ has started the production (or conversion) process for the order line, meaning that it can't be changed anymore (`"changeable": true`). Then, the _Order Issuer_ sends an API request to the _Supplier_ in order to get the details of the second order `c898aa54-8ebb-40ab-a0b9-3d979e082a9e`:
+The step 3 of the scenario C will simulate the situation in which the _Supplier_ has started the production (or conversion) process for the order line, meaning that it can't be changed anymore (`"changeable": false`). Then, the _Order Issuer_ sends an API request to the _Supplier_ in order to get the details of the second order `c898aa54-8ebb-40ab-a0b9-3d979e082a9e`:
 
 ```text
 $ curl --request GET \
@@ -1371,7 +1370,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "29868f71-46a0-4757-981e-1ad26a4cb3c1",
-      "orderLineItemNumber": 1,
+      "orderLineItemNumber": "1",
       "orderLineItemStatus": "Confirmed",
       "changeable": false,
       "quantities": [
@@ -1400,7 +1399,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
 }
 ```
 
-It shows that the first (and unique) line is still `Confirmed`, but cannot be changed anymore (`"changeable": true`).
+It shows that the first (and unique) line is still `Confirmed`, but cannot be changed anymore (`"changeable": false`).
 
 #### Step 4 of Scenario C
 
@@ -1431,7 +1430,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "29868f71-46a0-4757-981e-1ad26a4cb3c1",
-      "orderLineItemNumber": 1,
+      "orderLineItemNumber": "1",
       "orderLineItemStatus": "ProductionCompleted",
       "changeable": false,
       "quantities": [
@@ -1503,7 +1502,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "29868f71-46a0-4757-981e-1ad26a4cb3c1",
-      "orderLineItemNumber": 1,
+      "orderLineItemNumber": "1",
       "orderLineItemStatus": "ProductionCompleted",
       "changeable": false,
       "quantities": [
@@ -1587,7 +1586,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "29868f71-46a0-4757-981e-1ad26a4cb3c1",
-      "orderLineItemNumber": 1,
+      "orderLineItemNumber": "1",
       "orderLineItemStatus": "ShipmentCompleted",
       "changeable": false,
       "quantities": [
@@ -1671,7 +1670,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "29868f71-46a0-4757-981e-1ad26a4cb3c1",
-      "orderLineItemNumber": 1,
+      "orderLineItemNumber": "1",
       "orderLineItemStatus": "Completed",
       "changeable": false,
       "quantities": [
@@ -1763,7 +1762,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "1c9192cb-10d4-4e2e-a3d0-bcb4d67eb605",
-      "orderLineItemNumber": 1,
+      "orderLineItemNumber": "1",
       "orderLineItemStatus": "Pending",
       "changeable": true,
       "quantities": [
@@ -1811,7 +1810,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "1c9192cb-10d4-4e2e-a3d0-bcb4d67eb605",
-      "orderLineItemNumber": 1,
+      "orderLineItemNumber": "1",
       "orderLineItemStatus": "Confirmed",
       "changeable": true,
       "quantities": [
@@ -1844,7 +1843,7 @@ It shows that the first (and unique) line is now `Confirmed`, but can still be c
 
 #### Step 3 of Scenario D
 
-The step 3 of the scenario D will simulate the situation in which the _Supplier_ has started the production (or conversion) process for the order line, meaning that it can't be changed anymore (`"changeable": true`). Then, the _Order Issuer_ sends another similar API request to the _Supplier_ in order to get the details of the first order `fb441640-e40b-4d91-8930-61ebf981da63`:
+The step 3 of the scenario D will simulate the situation in which the _Supplier_ has started the production (or conversion) process for the order line, meaning that it can't be changed anymore (`"changeable": false`). Then, the _Order Issuer_ sends another similar API request to the _Supplier_ in order to get the details of the first order `fb441640-e40b-4d91-8930-61ebf981da63`:
 
 ```text
 $ curl --request GET \
@@ -1871,7 +1870,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "1c9192cb-10d4-4e2e-a3d0-bcb4d67eb605",
-      "orderLineItemNumber": 1,
+      "orderLineItemNumber": "1",
       "orderLineItemStatus": "Confirmed",
       "changeable": false,
       "quantities": [
@@ -1900,7 +1899,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
 }
 ```
 
-It shows that the first (and unique) line is still `Confirmed`, but cannot be changed anymore (`"changeable": true`).
+It shows that the first (and unique) line is still `Confirmed`, but cannot be changed anymore (`"changeable": false`).
 
 #### Step 4 of Scenario D
 
@@ -1931,7 +1930,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "1c9192cb-10d4-4e2e-a3d0-bcb4d67eb605",
-      "orderLineItemNumber": 1,
+      "orderLineItemNumber": "1",
       "orderLineItemStatus": "Confirmed",
       "changeable": false,
       "quantities": [
@@ -2003,7 +2002,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "1c9192cb-10d4-4e2e-a3d0-bcb4d67eb605",
-      "orderLineItemNumber": 1,
+      "orderLineItemNumber": "1",
       "orderLineItemStatus": "Confirmed",
       "changeable": false,
       "quantities": [
@@ -2056,7 +2055,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
 }
 ```
 
-It shows ...
+It shows that the first (and unique) line is still on the status `Confirmed`, while quantities have been updated, using the contexts `Produced`and `Shipped`.
 
 #### Step 6 of Scenario D
 
@@ -2087,7 +2086,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "1c9192cb-10d4-4e2e-a3d0-bcb4d67eb605",
-      "orderLineItemNumber": 1,
+      "orderLineItemNumber": "1",
       "orderLineItemStatus": "ProductionCompleted",
       "changeable": false,
       "quantities": [
@@ -2140,11 +2139,11 @@ If all goes well, the _Order Issuer_ will receive a response like this:
 }
 ```
 
-It shows ...
+It shows that the first (and unique) line has now reached the status `ProductionCompleted`, while quantities have been updated, using the contexts `Produced`and `Shipped`.
 
 #### Step 7 of Scenario D
 
-The step 6 of the scenario D will simulate the situation in which the _Supplier_ has completed the production (or conversion) process for the order line, while still partially completed the shipment for the order line. Then, the _Order Issuer_ sends another similar API request to the _Supplier_ in order to get the details of the first order `fb441640-e40b-4d91-8930-61ebf981da63`:
+The step 7 of the scenario D will simulate the situation in which the _Supplier_ has completed the production (or conversion) process for the order line, while still partially completed the shipment for the order line. Then, the _Order Issuer_ sends another similar API request to the _Supplier_ in order to get the details of the first order `fb441640-e40b-4d91-8930-61ebf981da63`:
 
 ```text
 $ curl --request GET \
@@ -2171,7 +2170,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "1c9192cb-10d4-4e2e-a3d0-bcb4d67eb605",
-      "orderLineItemNumber": 1,
+      "orderLineItemNumber": "1",
       "orderLineItemStatus": "ProductionCompleted",
       "changeable": false,
       "quantities": [
@@ -2224,7 +2223,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
 }
 ```
 
-It shows ...
+It shows that the first (and unique) line is still on the status `ProductionCompleted`, while quantities have been updated, using the context `Shipped`.
 
 #### Step 8 of Scenario D
 
@@ -2255,7 +2254,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "1c9192cb-10d4-4e2e-a3d0-bcb4d67eb605",
-      "orderLineItemNumber": 1,
+      "orderLineItemNumber": "1",
       "orderLineItemStatus": "ShipmentCompleted",
       "changeable": false,
       "quantities": [
@@ -2339,7 +2338,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "1c9192cb-10d4-4e2e-a3d0-bcb4d67eb605",
-      "orderLineItemNumber": 1,
+      "orderLineItemNumber": "1",
       "orderLineItemStatus": "Completed",
       "changeable": false,
       "quantities": [
@@ -2404,7 +2403,7 @@ It shows that the first (and unique) line, as well as the order `1004`, has now 
 
 #### Step 1 of Scenario E
 
-The step 1 of the scenario D will simulate the situation in which the (unique) line is `Pending` and can still be changed (`"changeable": true`). Then, the _Order Issuer_ sends another similar API request to the _Supplier_ in order to get the details of the first order `12e8667f-14ed-49e6-9610-dc58dee95560`:
+The step 1 of the scenario E will simulate the situation in which the (unique) line is `Pending` and can still be changed (`"changeable": true`). Then, the _Order Issuer_ sends another similar API request to the _Supplier_ in order to get the details of the first order `12e8667f-14ed-49e6-9610-dc58dee95560`:
 
 ```text
 $ curl --request GET \
@@ -2431,7 +2430,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "1deca55f-2d03-4c18-93d0-c60362b891a5",
-      "orderLineItemNumber": 1,
+      "orderLineItemNumber": "1",
       "orderLineItemStatus": "Pending",
       "changeable": true,
       "quantities": [
@@ -2452,7 +2451,7 @@ It shows that the order `1005` has been well received by the _Supplier_ and is _
 
 #### Step 2 of Scenario E
 
-The step 2 of the scenario D will simulate the situation in which the _Supplier_ has processed the order and confirmed the ordered quantities. Then, the _Order Issuer_ sends another similar API request to the _Supplier_ in order to get the details of the first order `12e8667f-14ed-49e6-9610-dc58dee95560`:
+The step 2 of the scenario E will simulate the situation in which the _Supplier_ has processed the order and confirmed the ordered quantities. Then, the _Order Issuer_ sends another similar API request to the _Supplier_ in order to get the details of the first order `12e8667f-14ed-49e6-9610-dc58dee95560`:
 
 ```text
 $ curl --request GET \
@@ -2479,7 +2478,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "1deca55f-2d03-4c18-93d0-c60362b891a5",
-      "orderLineItemNumber": 1,
+      "orderLineItemNumber": "1",
       "orderLineItemStatus": "Confirmed",
       "changeable": true,
       "quantities": [
@@ -2512,7 +2511,7 @@ It shows that the first (and unique) line is now `Confirmed`, but can still be c
 
 #### Step 3 of Scenario E
 
-The step 3 of the scenario D will simulate the situation in which the _Supplier_ has started the production (or conversion) process for the order line, meaning that it can't be changed anymore (`"changeable": true`). Then, the _Order Issuer_ sends another similar API request to the _Supplier_ in order to get the details of the first order `12e8667f-14ed-49e6-9610-dc58dee95560`:
+The step 3 of the scenario E will simulate the situation in which the _Supplier_ has started the production (or conversion) process for the order line, meaning that it can't be changed anymore (`"changeable": false`). Then, the _Order Issuer_ sends another similar API request to the _Supplier_ in order to get the details of the first order `12e8667f-14ed-49e6-9610-dc58dee95560`:
 
 ```text
 $ curl --request GET \
@@ -2539,7 +2538,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "1deca55f-2d03-4c18-93d0-c60362b891a5",
-      "orderLineItemNumber": 1,
+      "orderLineItemNumber": "1",
       "orderLineItemStatus": "Confirmed",
       "changeable": false,
       "quantities": [
@@ -2568,7 +2567,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
 }
 ```
 
-It shows that the first (and unique) line is still `Confirmed`, but cannot be changed anymore (`"changeable": true`).
+It shows that the first (and unique) line is still `Confirmed`, but cannot be changed anymore (`"changeable": false`).
 
 #### Step 4 of Scenario E
 
@@ -2599,7 +2598,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "1deca55f-2d03-4c18-93d0-c60362b891a5",
-      "orderLineItemNumber": 1,
+      "orderLineItemNumber": "1",
       "orderLineItemStatus": "ProductionCompleted",
       "changeable": false,
       "quantities": [
@@ -2671,7 +2670,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "1deca55f-2d03-4c18-93d0-c60362b891a5",
-      "orderLineItemNumber": 1,
+      "orderLineItemNumber": "1",
       "orderLineItemStatus": "ShipmentCompleted",
       "changeable": false,
       "quantities": [
@@ -2755,7 +2754,7 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "orderLineItems": [
     {
       "id": "1deca55f-2d03-4c18-93d0-c60362b891a5",
-      "orderLineItemNumber": 1,
+      "orderLineItemNumber": "1",
       "orderLineItemStatus": "Completed",
       "changeable": false,
       "quantities": [
@@ -2816,417 +2815,3 @@ If all goes well, the _Order Issuer_ will receive a response like this:
 
 It shows that the first (and unique) line, as well as the order `1005`, has now reached the status `Completed`. The quantities have been updated accordingly, using the context `Invoiced`. Notice that only the quantity of type `Count` is not relevant in the context `Invoiced`.
 
-### Scenario F - Over Shipment
-
-#### Step 1 of Scenario F
-
-The step 1 of the scenario D will simulate the situation in which the (unique) line is `Pending` and can still be changed (`"changeable": true`). Then, the _Order Issuer_ sends another similar API request to the _Supplier_ in order to get the details of the first order `1804bcfb-15ae-476a-bc8b-f31bc9f4de62`:
-
-```text
-$ curl --request GET \
-  --URL https://api.papinet.io/orders/1804bcfb-15ae-476a-bc8b-f31bc9f4de62 \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
-```
-
-or, if you use locally the docker container of the papiNet mock server:
-
-```text
-$ curl --request GET \
-  --URL http://localhost:3001/orders/1804bcfb-15ae-476a-bc8b-f31bc9f4de62 \
-  --header 'X-papiNet-Domain: papinet.papinet.io' \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
-
-If all goes well, the _Order Issuer_ will receive a response like this:
-
-```json
-{
-  "id": "1804bcfb-15ae-476a-bc8b-f31bc9f4de62",
-  "orderNumber": "1006",
-  "orderStatus": "Active",
-  "numberOfLineItems": 1,
-  "orderLineItems": [
-    {
-      "id": "fc890c7d-39e5-4181-8040-affde22edf89",
-      "orderLineItemNumber": 1,
-      "orderLineItemStatus": "Pending",
-      "changeable": true,
-      "quantities": [
-        {
-        "quantityContext": "Ordered",
-        "quantityType": "GrossWeight",
-        "quantityValue": 10000,
-        "quantityUOM": "Kilogram"
-        }
-      ]
-    }
-  ],
-  "links": {}
-}
-```
-
-It shows that the order `1006` has been well received by the _Supplier_ and is _Active_. Its first (and unique) line is still `Pending` and can still be changed (`"changeable": true`).
-
-#### Step 2 of Scenario F
-
-The step 2 of the scenario D will simulate the situation in which the _Supplier_ has processed the order and confirmed the ordered quantities. Then, the _Order Issuer_ sends another similar API request to the _Supplier_ in order to get the details of the first order `1804bcfb-15ae-476a-bc8b-f31bc9f4de62`:
-
-```text
-$ curl --request GET \
-  --URL https://api.papinet.io/orders/1804bcfb-15ae-476a-bc8b-f31bc9f4de62 \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
-```
-
-or, if you use locally the docker container of the papiNet mock server:
-
-```text
-$ curl --request GET \
-  --URL http://localhost:3001/orders/1804bcfb-15ae-476a-bc8b-f31bc9f4de62 \
-  --header 'X-papiNet-Domain: papinet.papinet.io' \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
-
-If all goes well, the _Order Issuer_ will receive a response like this:
-
-```json
-{
-  "id": "1804bcfb-15ae-476a-bc8b-f31bc9f4de62",
-  "orderNumber": "1006",
-  "orderStatus": "Active",
-  "numberOfLineItems": 1,
-  "orderLineItems": [
-    {
-      "id": "fc890c7d-39e5-4181-8040-affde22edf89",
-      "orderLineItemNumber": 1,
-      "orderLineItemStatus": "Confirmed",
-      "changeable": true,
-      "quantities": [
-        {
-        "quantityContext": "Ordered",
-        "quantityType": "GrossWeight",
-        "quantityValue": 10000,
-        "quantityUOM": "Kilogram"
-        },
-        {
-          "quantityContext": "Confirmed",
-          "quantityType": "GrossWeight",
-          "quantityValue": 9600,
-          "quantityUOM": "Kilogram"
-        },
-        {
-          "quantityContext": "Confirmed",
-          "quantityType": "Count",
-          "quantityValue": 3,
-          "quantityUOM": "Reel"
-        }
-      ]
-    }
-  ],
-  "links": {}
-}
-```
-
-It shows that the first (and unique) line is now `Confirmed`, but can still be changed (`"changeable": true`), as the quantities have been _Confirmed_.
-
-#### Step 3 of Scenario F
-
-The step 3 of the scenario D will simulate the situation in which the _Supplier_ has started the production (or conversion) process for the order line, meaning that it can't be changed anymore (`"changeable": true`). Then, the _Order Issuer_ sends another similar API request to the _Supplier_ in order to get the details of the first order `1804bcfb-15ae-476a-bc8b-f31bc9f4de62`:
-
-```text
-$ curl --request GET \
-  --URL https://api.papinet.io/orders/1804bcfb-15ae-476a-bc8b-f31bc9f4de62 \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
-```
-
-or, if you use locally the docker container of the papiNet mock server:
-
-```text
-$ curl --request GET \
-  --URL http://localhost:3001/orders/1804bcfb-15ae-476a-bc8b-f31bc9f4de62 \
-  --header 'X-papiNet-Domain: papinet.papinet.io' \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
-
-If all goes well, the _Order Issuer_ will receive a response like this:
-
-```json
-{
-  "id": "1804bcfb-15ae-476a-bc8b-f31bc9f4de62",
-  "orderNumber": "1006",
-  "orderStatus": "Active",
-  "numberOfLineItems": 1,
-  "orderLineItems": [
-    {
-      "id": "fc890c7d-39e5-4181-8040-affde22edf89",
-      "orderLineItemNumber": 1,
-      "orderLineItemStatus": "Confirmed",
-      "changeable": false,
-      "quantities": [
-        {
-        "quantityContext": "Ordered",
-        "quantityType": "GrossWeight",
-        "quantityValue": 10000,
-        "quantityUOM": "Kilogram"
-        },
-        {
-          "quantityContext": "Confirmed",
-          "quantityType": "GrossWeight",
-          "quantityValue": 9600,
-          "quantityUOM": "Kilogram"
-        },
-        {
-          "quantityContext": "Confirmed",
-          "quantityType": "Count",
-          "quantityValue": 3,
-          "quantityUOM": "Reel"
-        }
-      ]
-    }
-  ],
-  "links": {}
-}
-```
-
-It shows that the first (and unique) line is still `Confirmed`, but cannot be changed anymore (`"changeable": true`).
-
-#### Step 4 of Scenario F
-
-The step 4 of the scenario E will simulate the situation in which the _Supplier_ has completed the production (or conversion) process for the order line. Then, the _Order Issuer_ sends another similar API request to the _Supplier_ in order to get the details of the first order `1804bcfb-15ae-476a-bc8b-f31bc9f4de62`:
-
-```text
-$ curl --request GET \
-  --URL https://api.papinet.io/orders/1804bcfb-15ae-476a-bc8b-f31bc9f4de62 \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
-```
-
-or, if you use locally the docker container of the papiNet mock server:
-
-```text
-$ curl --request GET \
-  --URL http://localhost:3001/orders/1804bcfb-15ae-476a-bc8b-f31bc9f4de62 \
-  --header 'X-papiNet-Domain: papinet.papinet.io' \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
-
-If all goes well, the _Order Issuer_ will receive a response like this:
-
-```json
-{
-  "id": "1804bcfb-15ae-476a-bc8b-f31bc9f4de62",
-  "orderStatus": "Active",
-  "numberOfLineItems": 1,
-  "orderLineItems": [
-    {
-      "id": "fc890c7d-39e5-4181-8040-affde22edf89",
-      "orderLineItemNumber": 1,
-      "orderLineItemStatus": "ProductionCompleted",
-      "changeable": false,
-      "quantities": [
-        {
-        "quantityContext": "Ordered",
-        "quantityType": "GrossWeight",
-        "quantityValue": 10000,
-        "quantityUOM": "Kilogram"
-        },
-        {
-          "quantityContext": "Confirmed",
-          "quantityType": "GrossWeight",
-          "quantityValue": 9600,
-          "quantityUOM": "Kilogram"
-        },
-        {
-          "quantityContext": "Confirmed",
-          "quantityType": "Count",
-          "quantityValue": 3,
-          "quantityUOM": "Reel"
-        },
-        {
-          "quantityContext": "Produced",
-          "quantityType": "GrossWeight",
-          "quantityValue": 9900,
-          "quantityUOM": "Kilogram"
-        },
-        {
-          "quantityContext": "Produced",
-          "quantityType": "Count",
-          "quantityValue": 3,
-          "quantityUOM": "Reel"
-        }
-      ]
-    }
-  ],
-  "links": {}
-}
-```
-
-It shows that the first (and unique) line has now reached the status `ProductionCompleted`. The quantities have been updated accordingly, using the context `Produced`.
-
-#### Step 5 of Scenario F
-
-The step 5 of the scenario E will simulate the situation in which the _Supplier_ has completed the shipment for the order line. It means that all the products have left the _Supplier_ location. Then, the _Order Issuer_ sends another similar API request to the _Supplier_ in order to get the details of the first order `1804bcfb-15ae-476a-bc8b-f31bc9f4de62`:
-
-```text
-$ curl --request GET \
-  --URL https://api.papinet.io/orders/1804bcfb-15ae-476a-bc8b-f31bc9f4de62 \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
-```
-
-or, if you use locally the docker container of the papiNet mock server:
-
-```text
-$ curl --request GET \
-  --URL http://localhost:3001/orders/1804bcfb-15ae-476a-bc8b-f31bc9f4de62 \
-  --header 'X-papiNet-Domain: papinet.papinet.io' \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
-
-If all goes well, the _Order Issuer_ will receive a response like this:
-
-```json
-{
-  "id": "1804bcfb-15ae-476a-bc8b-f31bc9f4de62",
-  "orderNumber": "1006",
-  "orderStatus": "Active",
-  "numberOfLineItems": 1,
-  "orderLineItems": [
-    {
-      "id": "fc890c7d-39e5-4181-8040-affde22edf89",
-      "orderLineItemNumber": 1,
-      "orderLineItemStatus": "ShipmentCompleted",
-      "changeable": false,
-      "quantities": [
-        {
-        "quantityContext": "Ordered",
-        "quantityType": "GrossWeight",
-        "quantityValue": 10000,
-        "quantityUOM": "Kilogram"
-        },
-        {
-          "quantityContext": "Confirmed",
-          "quantityType": "GrossWeight",
-          "quantityValue": 9600,
-          "quantityUOM": "Kilogram"
-        },
-        {
-          "quantityContext": "Confirmed",
-          "quantityType": "Count",
-          "quantityValue": 3,
-          "quantityUOM": "Reel"
-        },
-        {
-          "quantityContext": "Produced",
-          "quantityType": "GrossWeight",
-          "quantityValue": 9900,
-          "quantityUOM": "Kilogram"
-        },
-        {
-          "quantityContext": "Produced",
-          "quantityType": "Count",
-          "quantityValue": 3,
-          "quantityUOM": "Reel"
-        },
-        {
-          "quantityContext": "Shipped",
-          "quantityType": "GrossWeight",
-          "quantityValue": 16000,
-          "quantityUOM": "Kilogram"
-        },
-        {
-          "quantityContext": "Shipped",
-          "quantityType": "Count",
-          "quantityValue": 5,
-          "quantityUOM": "Reel"
-        }
-      ]
-    }
-  ],
-  "links": {}
-}
-```
-
-It shows that the first (and unique) line has now reached the status `ShipmentCompleted`, despite the fact that `Shipped` quantities are more than the `Produced` quantities.
-
-#### Step 6 of Scenario F
-
-The step 6 of the scenario E will simulate the situation in which the _Supplier_ has sent an invoice referring to the order line. Then, the _Order Issuer_ sends another similar API request to the _Supplier_ in order to get the details of the first order `1804bcfb-15ae-476a-bc8b-f31bc9f4de62`:
-
-```text
-$ curl --request GET \
-  --URL https://api.papinet.io/orders/1804bcfb-15ae-476a-bc8b-f31bc9f4de62 \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
-```
-
-or, if you use locally the docker container of the papiNet mock server:
-
-```text
-$ curl --request GET \
-  --URL http://localhost:3001/orders/1804bcfb-15ae-476a-bc8b-f31bc9f4de62 \
-  --header 'X-papiNet-Domain: papinet.papinet.io' \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
-
-If all goes well, the _Order Issuer_ will receive a response like this:
-
-```json
-{
-  "id": "1804bcfb-15ae-476a-bc8b-f31bc9f4de62",
-  "orderNumber": "1006",
-  "orderStatus": "Completed",
-  "numberOfLineItems": 1,
-  "orderLineItems": [
-    {
-      "id": "fc890c7d-39e5-4181-8040-affde22edf89",
-      "orderLineItemNumber": 1,
-      "orderLineItemStatus": "Completed",
-      "changeable": false,
-      "quantities": [
-        {
-        "quantityContext": "Ordered",
-        "quantityType": "GrossWeight",
-        "quantityValue": 10000,
-        "quantityUOM": "Kilogram"
-        },
-        {
-          "quantityContext": "Confirmed",
-          "quantityType": "GrossWeight",
-          "quantityValue": 9600,
-          "quantityUOM": "Kilogram"
-        },
-        {
-          "quantityContext": "Confirmed",
-          "quantityType": "Count",
-          "quantityValue": 3,
-          "quantityUOM": "Reel"
-        },
-        {
-          "quantityContext": "Produced",
-          "quantityType": "GrossWeight",
-          "quantityValue": 9900,
-          "quantityUOM": "Kilogram"
-        },
-        {
-          "quantityContext": "Produced",
-          "quantityType": "Count",
-          "quantityValue": 3,
-          "quantityUOM": "Reel"
-        },
-        {
-          "quantityContext": "Shipped",
-          "quantityType": "GrossWeight",
-          "quantityValue": 16000,
-          "quantityUOM": "Kilogram"
-        },
-        {
-          "quantityContext": "Shipped",
-          "quantityType": "Count",
-          "quantityValue": 5,
-          "quantityUOM": "Reel"
-        },
-        {
-          "quantityContext": "Invoiced",
-          "quantityType": "GrossWeight",
-          "quantityValue": 16000,
-          "quantityUOM": "Kilogram"
-        }
-      ]
-    }
-  ],
-  "links": {}
-}
-```
-
-It shows that the first (and unique) line, as well as the order `1006`, has now reached the status `Completed`. The quantities have been updated accordingly, using the context `Invoiced`. Notice that only the quantity of type `Count` is not relevant in the context `Invoiced`.


### PR DESCRIPTION
I have corrected errors in the text and deleted Scenario F Over Shipment.
If some reels are taken from stock, then they are normally included in Produced quantity. It would mean that Produced and Shipped quantities would be the same when ShipmentCompleted, so this isn't really a new scenario.

We also have other scenarios, e.g. the products can be invoiced before they are shipped. We have a major difference in this scenario compared to existing scenarios, orderStatus=Completed is after ShipmentCompleted and not after the issue of the invoice as in existing scenarios.
How do we communicate the status that the order line items are invoiced when invoicing is done before shipments? Or is it enough to report only an Invoiced quantity?
Should we add this scenario?

We should also discuss if we need more quantity types. E.g. a merchant is selling sheeted paper from stock, would he use quantity type Produced in the API response, when he has allocated stock items to the customer order? The merchant is the supplier in this case.