### PR TITLE
Finalize and deploy the papiNet mock server to support 1.1.0 release (Shipment Status)

### DIFF
--- a/1.1.0/mock/app.js
+++ b/1.1.0/mock/app.js
@@ -5,7 +5,12 @@ const bodyParser = require('body-parser')
 const short = require('short-uuid')
 const jsonfile = require('jsonfile')
 
-const PORT = 3001
+/*
+We will one specific TCP port per release with the following mapping:
+3001 = 1.0.0
+3002 = 1.1.0
+*/
+const PORT = 3002
 const HOST = '0.0.0.0'
 const SERVICE_NAME = 'papinet-mock'
 const SERVICE_VERSION = '1.1.0'
@@ -41,6 +46,46 @@ const scenarios = [
     name: "A",
     firstStep: 1,
     lastStep: 6,
+    previousStep: 0
+  },
+  {
+    method: "GET",
+    domain:"papinet.papinet.io",
+    path: "/orders/778fe5cb-f7ac-4493-b492-25fe98df67c4",
+    useCase: "order-status-use-case",
+    name: "B",
+    firstStep: 1,
+    lastStep: 8,
+    previousStep: 0
+  },
+  {
+    method: "GET",
+    domain:"papinet.papinet.io",
+    path: "/orders/c898aa54-8ebb-40ab-a0b9-3d979e082a9e",
+    useCase: "order-status-use-case",
+    name: "C",
+    firstStep: 1,
+    lastStep: 7,
+    previousStep: 0
+  },
+  {
+    method: "GET",
+    domain:"papinet.papinet.io",
+    path: "/orders/fb441640-e40b-4d91-8930-61ebf981da63",
+    useCase: "order-status-use-case",
+    name: "D",
+    firstStep: 1,
+    lastStep: 9,
+    previousStep: 0
+  },
+  {
+    method: "GET",
+    domain:"papinet.papinet.io",
+    path: "/orders/12e8667f-14ed-49e6-9610-dc58dee95560",
+    useCase: "order-status-use-case",
+    name: "E",
+    firstStep: 1,
+    lastStep: 7,
     previousStep: 0
   },
   {
@@ -107,6 +152,10 @@ const scenarios = [
 const scenariosIndexedByAPIEndpoint = [
   "GET|papinet.papinet.io|/orders",
   "GET|papinet.papinet.io|/orders/c51d8903-01d1-485c-96ce-51a9be192207",
+  "GET|papinet.papinet.io|/orders/778fe5cb-f7ac-4493-b492-25fe98df67c4",
+  "GET|papinet.papinet.io|/orders/c898aa54-8ebb-40ab-a0b9-3d979e082a9e",
+  "GET|papinet.papinet.io|/orders/fb441640-e40b-4d91-8930-61ebf981da63",
+  "GET|papinet.papinet.io|/orders/12e8667f-14ed-49e6-9610-dc58dee95560",
   "GET|papinet.road.papinet.io|/shipments",
   "GET|papinet.road.papinet.io|/shipments/c51d8903-01d1-485c-96ce-51a9be192207",
   "GET|papinet.fast.papinet.io|/shipments",
@@ -120,8 +169,7 @@ app.post('/tokens', (req, res) => {
   const traceId = short.uuid()
   console.log(`[INFO] [${traceId}] post /tokens [${Date.now()}] `)
   const id = short.uuid()
-  // X-papiNet-Domain
-  const domain = req.header('X-papiNet-Domain')
+  const domain = req.hostname // Contains the hostname derived from the Host HTTP header.
   console.log(`[INFO] [${traceId}]   domain = ${domain} [${Date.now()}]`)
 
   //const scenarioPos = scenariosIndexedByParty.indexOf(party)
@@ -508,7 +556,7 @@ function handle(traceId, method, path, req, res) {
   const sessionDomain = sessions[sessionPos].domain
   console.log(`[INFO] [${traceId}]   sessionDomain: ${sessionDomain}`)
 
-  const domain = req.header('X-papiNet-Domain')
+  const domain = req.hostname // Contains the hostname derived from the Host HTTP header.
   console.log(`[INFO] [${traceId}]   domain: ${domain}`)
 
   if (sessionDomain !== domain) {

--- a/1.1.0/mock/install.md
+++ b/1.1.0/mock/install.md
@@ -1,0 +1,113 @@
+# Install the papiNet API Mock Service
+
+## Create a Virtual Machine (VM)
+
+1\. Create a Virtual Machine with a public IP address, as well as with HTTP (80) and HTTPS (443) traffic allowed.
+
+## Domain Name
+
+1\. Create an DNS `A Record` with name `papinet.papinet.io` and the public IP address from above.
+2\. Create an DNS `A Record` with name `papinet.pulp.papinet.io` and the public IP address from above.
+3\. Create an DNS `A Record` with name `papinet.fast.papinet.io` and the public IP address from above.
+4\. Create an DNS `A Record` with name `papinet.road.papinet.io` and the public IP address from above.
+5\. Create an DNS `A Record` with name `papinet.corp.papinet.io` and the public IP address from above.
+
+## Install NGINX
+
+1\. Download and install NGINX:
+
+```text
+$ sudo apt-get update
+$ sudo apt-get install -y nginx
+```
+
+2\. Test the installation by opening <http://papinet.papinet.io> in a browser.
+
+## Install Node.js
+
+1\. Download and install Node.js:
+
+```text
+~$ curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
+~$ sudo apt-get install -y nodejs
+```
+
+2\. Check the installation:
+
+```text
+~$ node --version
+v12.18.0
+~$ npm --version
+6.14.11
+```
+
+## Install and Run the papiNet API Mock Service
+
+1\. Create a `papinet-mock-service-1-1-0` folder:
+
+```text
+$ mkdir papinet-mock-service-1-1-0
+$ cd papinet-mock-service-1-1-0/
+```
+
+2\. Upload the needed files into the `papinet-mock-service-1-1-0` folder using the `upload.cmd` windows command script.
+
+3\. Install the dependencies by typing the following command:
+
+```text
+~$ npm install
+```
+
+5\. Install the PM2 daemon process manager (that will help you manage and keep your application online 24/7):
+
+```text
+~$ sudo npm install pm2@latest -g
+```
+
+6\. Start the papiNet mock service with PM2:
+
+```text
+~$ pm2 start app.js --name papinet-mock-service-1-1-0
+```
+
+7\. Check locally if the papiNet mock service is properly running:
+
+```text
+~$ curl localhost:3002/orders
+...
+```
+
+## Configure NGINX
+
+1\. Upload the file `papinet.papinet.io` into the `papinet-mock-service-2021-01-16` folder.
+
+2\. Configure NGINX by typing the following commands:
+
+```text
+~$ ls /etc/nginx/sites-available
+~$ ls /etc/nginx/sites-enabled
+~$ sudo rm /etc/nginx/sites-enabled/default
+~$ cd ~/papinet-mock-service-1-1-0/nginx/
+~$ sudo mv *.conf /etc/nginx/sites-available
+~$ sudo ln -s /etc/nginx/sites-available/papinet.papinet.io.conf /etc/nginx/sites-enabled/papinet.papinet.io.conf
+~$ sudo ln -s /etc/nginx/sites-available/papinet.road.papinet.io.conf /etc/nginx/sites-enabled/papinet.road.papinet.io.conf
+~$ sudo ln -s /etc/nginx/sites-available/papinet.fast.papinet.io.conf /etc/nginx/sites-enabled/papinet.fast.papinet.io.conf
+~$ sudo ln -s /etc/nginx/sites-available/papinet.pulp.papinet.io.conf /etc/nginx/sites-enabled/papinet.pulp.papinet.io.conf
+~$ sudo service nginx configtest
+~$ sudo service nginx reload
+~$ sudo service nginx status
+```
+
+3\. Test the installation by opening <http://papinet.papinet.io/orders> in a browser.
+
+## Use _Let’s Encrypt_ to configure HTTPS
+
+1\. Let's update the NGINX configuration by typing the following commands:
+
+```text
+~$ sudo apt-get update
+~$ sudo apt-get install certbot
+~$ sudo certbot --nginx
+```
+
+2\. Test the installation by opening <https://papinet.papinet.io/orders> in a browser.

--- a/1.1.0/mock/nginx/papinet.fast.papinet.io.conf
+++ b/1.1.0/mock/nginx/papinet.fast.papinet.io.conf
@@ -1,0 +1,10 @@
+server {
+  listen 80;
+
+  server_name papinet.fast.papinet.io;
+
+  location / {
+    proxy_pass http://localhost:3002/;
+    proxy_set_header Host papinet.fast.papinet.io;
+  }
+}

--- a/1.1.0/mock/nginx/papinet.papinet.io.conf
+++ b/1.1.0/mock/nginx/papinet.papinet.io.conf
@@ -1,0 +1,10 @@
+server {
+  listen 80;
+
+  server_name papinet.papinet.io;
+
+  location / {
+    proxy_pass http://localhost:3002/;
+    proxy_set_header Host papinet.papinet.io;
+  }
+}

--- a/1.1.0/mock/nginx/papinet.pulp.papinet.io.conf
+++ b/1.1.0/mock/nginx/papinet.pulp.papinet.io.conf
@@ -1,0 +1,10 @@
+server {
+  listen 80;
+
+  server_name papinet.pulp.papinet.io;
+
+  location / {
+    proxy_pass http://localhost:3002/;
+    proxy_set_header Host papinet.pulp.papinet.io;
+  }
+}

--- a/1.1.0/mock/nginx/papinet.road.papinet.io.conf
+++ b/1.1.0/mock/nginx/papinet.road.papinet.io.conf
@@ -1,0 +1,10 @@
+server {
+  listen 80;
+
+  server_name papinet.road.papinet.io;
+
+  location / {
+    proxy_pass http://localhost:3002/;
+    proxy_set_header Host papinet.road.papinet.io;
+  }
+}

--- a/1.1.0/mock/upload.cmd
+++ b/1.1.0/mock/upload.cmd
@@ -1,0 +1,10 @@
+cmd /c gcloud compute ssh elfralalo@node-01 --command="mkdir /home/elfralalo/papinet-mock-service-1-1-0"
+cmd /c gcloud compute scp app.js              elfralalo@node-01:/home/elfralalo/papinet-mock-service-1-1-0/
+cmd /c gcloud compute scp package.json        elfralalo@node-01:/home/elfralalo/papinet-mock-service-1-1-0/
+cmd /c gcloud compute scp package-lock.json   elfralalo@node-01:/home/elfralalo/papinet-mock-service-1-1-0/
+
+cmd /c gcloud compute ssh elfralalo@node-01 --command="mkdir /home/elfralalo/papinet-mock-service-1-1-0/samples"
+cmd /c gcloud compute scp --recurse samples/ elfralalo@node-01:/home/elfralalo/papinet-mock-service-1-1-0/samples/
+
+cmd /c gcloud compute ssh elfralalo@node-01 --command="mkdir /home/elfralalo/papinet-mock-service-1-1-0/nginx"
+cmd /c gcloud compute scp --recurse nginx/ elfralalo@node-01:/home/elfralalo/papinet-mock-service-1-1-0/nginx/

--- a/1.1.0/order-status.md
+++ b/1.1.0/order-status.md
@@ -29,7 +29,7 @@ or, if you use locally the docker container of the papiNet mock server:
 
 ```text
 $ curl --request POST \
-  --URL http://localhost:3001/tokens \
+  --URL http://localhost:3002/tokens \
   --header 'Host: papinet.papinet.io' \
   --user 'public-36297346:private-ce2d3cf4' \
   --header 'Content-Type: application/x-www-form-urlencoded' \
@@ -59,7 +59,7 @@ $ export ACCESS_TOKEN=$(curl --request POST \
 or, if you use locally the docker container of the papiNet mock server:
 
 ```$ export ACCESS_TOKEN=$(curl --request POST \
-  --URL http://localhost:3001/tokens \
+  --URL http://localhost:3002/tokens \
   --header 'Host: papinet.papinet.io' \
   --user 'public-36297346:private-ce2d3cf4' \
   --header 'Content-Type: application/x-www-form-urlencoded' \
@@ -96,7 +96,7 @@ or, if you use locally the docker container of the papiNet mock server:
 
 ```text
 $ curl --request GET \
-  --URL http://localhost:3001/orders?orderStatus=Active \
+  --URL http://localhost:3002/orders?orderStatus=Active \
   --header 'Host: papinet.papinet.io' \
   --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
@@ -151,7 +151,7 @@ or, if you use locally the docker container of the papiNet mock server:
 
 ```text
 $ curl --request GET \
-  --URL http://localhost:3001/orders/c51d8903-01d1-485c-96ce-51a9be192207 \
+  --URL http://localhost:3002/orders/c51d8903-01d1-485c-96ce-51a9be192207 \
   --header 'Host: papinet.papinet.io' \
   --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
@@ -200,7 +200,7 @@ or, if you use locally the docker container of the papiNet mock server:
 
 ```text
 $ curl --request GET \
-  --URL http://localhost:3001/orders/c51d8903-01d1-485c-96ce-51a9be192207 \
+  --URL http://localhost:3002/orders/c51d8903-01d1-485c-96ce-51a9be192207 \
   --header 'Host: papinet.papinet.io' \
   --header 'Authorization: Bearer '$ACCESS_TOKEN
 
@@ -260,7 +260,7 @@ or, if you use locally the docker container of the papiNet mock server:
 
 ```text
 $ curl --request GET \
-  --URL http://localhost:3001/orders/c51d8903-01d1-485c-96ce-51a9be192207 \
+  --URL http://localhost:3002/orders/c51d8903-01d1-485c-96ce-51a9be192207 \
   --header 'Host: papinet.papinet.io' \
   --header 'Authorization: Bearer '$ACCESS_TOKEN
 
@@ -320,7 +320,7 @@ or, if you use locally the docker container of the papiNet mock server:
 
 ```text
 $ curl --request GET \
-  --URL http://localhost:3001/orders/c51d8903-01d1-485c-96ce-51a9be192207 \
+  --URL http://localhost:3002/orders/c51d8903-01d1-485c-96ce-51a9be192207 \
   --header 'Host: papinet.papinet.io' \
   --header 'Authorization: Bearer '$ACCESS_TOKEN
 
@@ -392,7 +392,7 @@ or, if you use locally the docker container of the papiNet mock server:
 
 ```text
 $ curl --request GET \
-  --URL http://localhost:3001/orders/c51d8903-01d1-485c-96ce-51a9be192207 \
+  --URL http://localhost:3002/orders/c51d8903-01d1-485c-96ce-51a9be192207 \
   --header 'Host: papinet.papinet.io' \
   --header 'Authorization: Bearer '$ACCESS_TOKEN
 
@@ -476,7 +476,7 @@ or, if you use locally the docker container of the papiNet mock server:
 
 ```text
 $ curl --request GET \
-  --URL http://localhost:3001/orders/c51d8903-01d1-485c-96ce-51a9be192207 \
+  --URL http://localhost:3002/orders/c51d8903-01d1-485c-96ce-51a9be192207 \
   --header 'Host: papinet.papinet.io' \
   --header 'Authorization: Bearer '$ACCESS_TOKEN
 
@@ -566,7 +566,7 @@ or, if you use locally the docker container of the papiNet mock server:
 
 ```text
 $ curl --request GET \
-  --URL http://localhost:3001/orders?orderStatus=Active \
+  --URL http://localhost:3002/orders?orderStatus=Active \
   --header 'Host: papinet.papinet.io' \
   --header 'Authorization: Bearer '$ACCESS_TOKEN
 
@@ -618,7 +618,7 @@ or, if you use locally the docker container of the papiNet mock server:
 
 ```text
 $ curl --request GET \
-  --URL http://localhost:3001/orders/778fe5cb-f7ac-4493-b492-25fe98df67c4 \
+  --URL http://localhost:3002/orders/778fe5cb-f7ac-4493-b492-25fe98df67c4 \
   --header 'Host: papinet.papinet.io' \
   --header 'Authorization: Bearer '$ACCESS_TOKEN
 
@@ -667,7 +667,7 @@ or, if you use locally the docker container of the papiNet mock server:
 
 ```text
 $ curl --request GET \
-  --URL http://localhost:3001/orders/778fe5cb-f7ac-4493-b492-25fe98df67c4 \
+  --URL http://localhost:3002/orders/778fe5cb-f7ac-4493-b492-25fe98df67c4 \
   --header 'Host: papinet.papinet.io' \
   --header 'Authorization: Bearer '$ACCESS_TOKEN
 
@@ -727,7 +727,7 @@ or, if you use locally the docker container of the papiNet mock server:
 
 ```text
 $ curl --request GET \
-  --URL http://localhost:3001/orders/778fe5cb-f7ac-4493-b492-25fe98df67c4 \
+  --URL http://localhost:3002/orders/778fe5cb-f7ac-4493-b492-25fe98df67c4 \
   --header 'Host: papinet.papinet.io' \
   --header 'Authorization: Bearer '$ACCESS_TOKEN
 
@@ -787,7 +787,7 @@ or, if you use locally the docker container of the papiNet mock server:
 
 ```text
 $ curl --request GET \
-  --URL http://localhost:3001/orders/778fe5cb-f7ac-4493-b492-25fe98df67c4 \
+  --URL http://localhost:3002/orders/778fe5cb-f7ac-4493-b492-25fe98df67c4 \
   --header 'Host: papinet.papinet.io' \
   --header 'Authorization: Bearer '$ACCESS_TOKEN
 
@@ -859,7 +859,7 @@ or, if you use locally the docker container of the papiNet mock server:
 
 ```text
 $ curl --request GET \
-  --URL http://localhost:3001/orders/778fe5cb-f7ac-4493-b492-25fe98df67c4 \
+  --URL http://localhost:3002/orders/778fe5cb-f7ac-4493-b492-25fe98df67c4 \
   --header 'Host: papinet.papinet.io' \
   --header 'Authorization: Bearer '$ACCESS_TOKEN
 
@@ -931,7 +931,7 @@ or, if you use locally the docker container of the papiNet mock server:
 
 ```text
 $ curl --request GET \
-  --URL http://localhost:3001/orders/778fe5cb-f7ac-4493-b492-25fe98df67c4 \
+  --URL http://localhost:3002/orders/778fe5cb-f7ac-4493-b492-25fe98df67c4 \
   --header 'Host: papinet.papinet.io' \
   --header 'Authorization: Bearer '$ACCESS_TOKEN
 
@@ -1003,7 +1003,7 @@ or, if you use locally the docker container of the papiNet mock server:
 
 ```text
 $ curl --request GET \
-  --URL http://localhost:3001/orders/778fe5cb-f7ac-4493-b492-25fe98df67c4 \
+  --URL http://localhost:3002/orders/778fe5cb-f7ac-4493-b492-25fe98df67c4 \
   --header 'Host: papinet.papinet.io' \
   --header 'Authorization: Bearer '$ACCESS_TOKEN
 
@@ -1087,7 +1087,7 @@ or, if you use locally the docker container of the papiNet mock server:
 
 ```text
 $ curl --request GET \
-  --URL http://localhost:3001/orders/778fe5cb-f7ac-4493-b492-25fe98df67c4 \
+  --URL http://localhost:3002/orders/778fe5cb-f7ac-4493-b492-25fe98df67c4 \
   --header 'Host: papinet.papinet.io' \
   --header 'Authorization: Bearer '$ACCESS_TOKEN
 
@@ -1177,7 +1177,7 @@ or, if you use locally the docker container of the papiNet mock server:
 
 ```text
 $ curl --request GET \
-  --URL http://localhost:3001/orders?orderStatus=Active \
+  --URL http://localhost:3002/orders?orderStatus=Active \
   --header 'Host: papinet.papinet.io' \
   --header 'Authorization: Bearer '$ACCESS_TOKEN
 
@@ -1225,7 +1225,7 @@ or, if you use locally the docker container of the papiNet mock server:
 
 ```text
 $ curl --request GET \
-  --URL http://localhost:3001/orders?orderStatus=Active&offset=2&limit=2 \
+  --URL http://localhost:3002/orders?orderStatus=Active&offset=2&limit=2 \
   --header 'Host: papinet.papinet.io' \
   --header 'Authorization: Bearer '$ACCESS_TOKEN
 
@@ -1275,7 +1275,7 @@ or, if you use locally the docker container of the papiNet mock server:
 
 ```text
 $ curl --request GET \
-  --URL http://localhost:3001/orders/c898aa54-8ebb-40ab-a0b9-3d979e082a9e \
+  --URL http://localhost:3002/orders/c898aa54-8ebb-40ab-a0b9-3d979e082a9e \
   --header 'Host: papinet.papinet.io' \
   --header 'Authorization: Bearer '$ACCESS_TOKEN
 
@@ -1323,7 +1323,7 @@ or, if you use locally the docker container of the papiNet mock server:
 
 ```text
 $ curl --request GET \
-  --URL http://localhost:3001/orders/c898aa54-8ebb-40ab-a0b9-3d979e082a9e \
+  --URL http://localhost:3002/orders/c898aa54-8ebb-40ab-a0b9-3d979e082a9e \
   --header 'Host: papinet.papinet.io' \
   --header 'Authorization: Bearer '$ACCESS_TOKEN
 
@@ -1383,7 +1383,7 @@ or, if you use locally the docker container of the papiNet mock server:
 
 ```text
 $ curl --request GET \
-  --URL http://localhost:3001/orders/c898aa54-8ebb-40ab-a0b9-3d979e082a9e \
+  --URL http://localhost:3002/orders/c898aa54-8ebb-40ab-a0b9-3d979e082a9e \
   --header 'Host: papinet.papinet.io' \
   --header 'Authorization: Bearer '$ACCESS_TOKEN
 
@@ -1443,7 +1443,7 @@ or, if you use locally the docker container of the papiNet mock server:
 
 ```text
 $ curl --request GET \
-  --URL http://localhost:3001/orders/c898aa54-8ebb-40ab-a0b9-3d979e082a9e \
+  --URL http://localhost:3002/orders/c898aa54-8ebb-40ab-a0b9-3d979e082a9e \
   --header 'Host: papinet.papinet.io' \
   --header 'Authorization: Bearer '$ACCESS_TOKEN
 
@@ -1515,7 +1515,7 @@ or, if you use locally the docker container of the papiNet mock server:
 
 ```text
 $ curl --request GET \
-  --URL http://localhost:3001/orders/c898aa54-8ebb-40ab-a0b9-3d979e082a9e \
+  --URL http://localhost:3002/orders/c898aa54-8ebb-40ab-a0b9-3d979e082a9e \
   --header 'Host: papinet.papinet.io' \
   --header 'Authorization: Bearer '$ACCESS_TOKEN
 
@@ -1599,7 +1599,7 @@ or, if you use locally the docker container of the papiNet mock server:
 
 ```text
 $ curl --request GET \
-  --URL http://localhost:3001/orders/c898aa54-8ebb-40ab-a0b9-3d979e082a9e \
+  --URL http://localhost:3002/orders/c898aa54-8ebb-40ab-a0b9-3d979e082a9e \
   --header 'Host: papinet.papinet.io' \
   --header 'Authorization: Bearer '$ACCESS_TOKEN
 
@@ -1683,7 +1683,7 @@ or, if you use locally the docker container of the papiNet mock server:
 
 ```text
 $ curl --request GET \
-  --URL http://localhost:3001/orders/c898aa54-8ebb-40ab-a0b9-3d979e082a9e \
+  --URL http://localhost:3002/orders/c898aa54-8ebb-40ab-a0b9-3d979e082a9e \
   --header 'Host: papinet.papinet.io' \
   --header 'Authorization: Bearer '$ACCESS_TOKEN
 
@@ -1775,7 +1775,7 @@ or, if you use locally the docker container of the papiNet mock server:
 
 ```text
 $ curl --request GET \
-  --URL http://localhost:3001/orders/fb441640-e40b-4d91-8930-61ebf981da63 \
+  --URL http://localhost:3002/orders/fb441640-e40b-4d91-8930-61ebf981da63 \
   --header 'Host: papinet.papinet.io' \
   --header 'Authorization: Bearer '$ACCESS_TOKEN
 
@@ -1823,7 +1823,7 @@ or, if you use locally the docker container of the papiNet mock server:
 
 ```text
 $ curl --request GET \
-  --URL http://localhost:3001/orders/fb441640-e40b-4d91-8930-61ebf981da63 \
+  --URL http://localhost:3002/orders/fb441640-e40b-4d91-8930-61ebf981da63 \
   --header 'Host: papinet.papinet.io' \
   --header 'Authorization: Bearer '$ACCESS_TOKEN
 
@@ -1883,7 +1883,7 @@ or, if you use locally the docker container of the papiNet mock server:
 
 ```text
 $ curl --request GET \
-  --URL http://localhost:3001/orders/fb441640-e40b-4d91-8930-61ebf981da63 \
+  --URL http://localhost:3002/orders/fb441640-e40b-4d91-8930-61ebf981da63 \
   --header 'Host: papinet.papinet.io' \
   --header 'Authorization: Bearer '$ACCESS_TOKEN
 
@@ -1943,7 +1943,7 @@ or, if you use locally the docker container of the papiNet mock server:
 
 ```text
 $ curl --request GET \
-  --URL http://localhost:3001/orders/fb441640-e40b-4d91-8930-61ebf981da63 \
+  --URL http://localhost:3002/orders/fb441640-e40b-4d91-8930-61ebf981da63 \
   --header 'Host: papinet.papinet.io' \
   --header 'Authorization: Bearer '$ACCESS_TOKEN
 
@@ -2015,7 +2015,7 @@ or, if you use locally the docker container of the papiNet mock server:
 
 ```text
 $ curl --request GET \
-  --URL http://localhost:3001/orders/fb441640-e40b-4d91-8930-61ebf981da63 \
+  --URL http://localhost:3002/orders/fb441640-e40b-4d91-8930-61ebf981da63 \
   --header 'Host: papinet.papinet.io' \
   --header 'Authorization: Bearer '$ACCESS_TOKEN
 
@@ -2099,7 +2099,7 @@ or, if you use locally the docker container of the papiNet mock server:
 
 ```text
 $ curl --request GET \
-  --URL http://localhost:3001/orders/fb441640-e40b-4d91-8930-61ebf981da63 \
+  --URL http://localhost:3002/orders/fb441640-e40b-4d91-8930-61ebf981da63 \
   --header 'Host: papinet.papinet.io' \
   --header 'Authorization: Bearer '$ACCESS_TOKEN
 
@@ -2183,7 +2183,7 @@ or, if you use locally the docker container of the papiNet mock server:
 
 ```text
 $ curl --request GET \
-  --URL http://localhost:3001/orders/fb441640-e40b-4d91-8930-61ebf981da63 \
+  --URL http://localhost:3002/orders/fb441640-e40b-4d91-8930-61ebf981da63 \
   --header 'Host: papinet.papinet.io' \
   --header 'Authorization: Bearer '$ACCESS_TOKEN
 
@@ -2267,7 +2267,7 @@ or, if you use locally the docker container of the papiNet mock server:
 
 ```text
 $ curl --request GET \
-  --URL http://localhost:3001/orders/fb441640-e40b-4d91-8930-61ebf981da63 \
+  --URL http://localhost:3002/orders/fb441640-e40b-4d91-8930-61ebf981da63 \
   --header 'Host: papinet.papinet.io' \
   --header 'Authorization: Bearer '$ACCESS_TOKEN
 
@@ -2351,7 +2351,7 @@ or, if you use locally the docker container of the papiNet mock server:
 
 ```text
 $ curl --request GET \
-  --URL http://localhost:3001/orders/fb441640-e40b-4d91-8930-61ebf981da63 \
+  --URL http://localhost:3002/orders/fb441640-e40b-4d91-8930-61ebf981da63 \
   --header 'Host: papinet.papinet.io' \
   --header 'Authorization: Bearer '$ACCESS_TOKEN
 
@@ -2443,7 +2443,7 @@ or, if you use locally the docker container of the papiNet mock server:
 
 ```text
 $ curl --request GET \
-  --URL http://localhost:3001/orders/12e8667f-14ed-49e6-9610-dc58dee95560 \
+  --URL http://localhost:3002/orders/12e8667f-14ed-49e6-9610-dc58dee95560 \
   --header 'Host: papinet.papinet.io' \
   --header 'Authorization: Bearer '$ACCESS_TOKEN
 
@@ -2491,7 +2491,7 @@ or, if you use locally the docker container of the papiNet mock server:
 
 ```text
 $ curl --request GET \
-  --URL http://localhost:3001/orders/12e8667f-14ed-49e6-9610-dc58dee95560 \
+  --URL http://localhost:3002/orders/12e8667f-14ed-49e6-9610-dc58dee95560 \
   --header 'Host: papinet.papinet.io' \
   --header 'Authorization: Bearer '$ACCESS_TOKEN
 
@@ -2551,7 +2551,7 @@ or, if you use locally the docker container of the papiNet mock server:
 
 ```text
 $ curl --request GET \
-  --URL http://localhost:3001/orders/12e8667f-14ed-49e6-9610-dc58dee95560 \
+  --URL http://localhost:3002/orders/12e8667f-14ed-49e6-9610-dc58dee95560 \
   --header 'Host: papinet.papinet.io' \
   --header 'Authorization: Bearer '$ACCESS_TOKEN
 
@@ -2611,7 +2611,7 @@ or, if you use locally the docker container of the papiNet mock server:
 
 ```text
 $ curl --request GET \
-  --URL http://localhost:3001/orders/12e8667f-14ed-49e6-9610-dc58dee95560 \
+  --URL http://localhost:3002/orders/12e8667f-14ed-49e6-9610-dc58dee95560 \
   --header 'Host: papinet.papinet.io' \
   --header 'Authorization: Bearer '$ACCESS_TOKEN
 
@@ -2683,7 +2683,7 @@ or, if you use locally the docker container of the papiNet mock server:
 
 ```text
 $ curl --request GET \
-  --URL http://localhost:3001/orders/12e8667f-14ed-49e6-9610-dc58dee95560 \
+  --URL http://localhost:3002/orders/12e8667f-14ed-49e6-9610-dc58dee95560 \
   --header 'Host: papinet.papinet.io' \
   --header 'Authorization: Bearer '$ACCESS_TOKEN
 
@@ -2767,7 +2767,7 @@ or, if you use locally the docker container of the papiNet mock server:
 
 ```text
 $ curl --request GET \
-  --URL http://localhost:3001/orders/12e8667f-14ed-49e6-9610-dc58dee95560 \
+  --URL http://localhost:3002/orders/12e8667f-14ed-49e6-9610-dc58dee95560 \
   --header 'Host: papinet.papinet.io' \
   --header 'Authorization: Bearer '$ACCESS_TOKEN
 
@@ -2859,7 +2859,7 @@ or, if you use locally the docker container of the papiNet mock server:
 
 ```text
 $ curl --request GET \
-  --URL http://localhost:3001/orders/1804bcfb-15ae-476a-bc8b-f31bc9f4de62 \
+  --URL http://localhost:3002/orders/1804bcfb-15ae-476a-bc8b-f31bc9f4de62 \
   --header 'Host: papinet.papinet.io' \
   --header 'Authorization: Bearer '$ACCESS_TOKEN
 
@@ -2907,7 +2907,7 @@ or, if you use locally the docker container of the papiNet mock server:
 
 ```text
 $ curl --request GET \
-  --URL http://localhost:3001/orders/1804bcfb-15ae-476a-bc8b-f31bc9f4de62 \
+  --URL http://localhost:3002/orders/1804bcfb-15ae-476a-bc8b-f31bc9f4de62 \
   --header 'Host: papinet.papinet.io' \
   --header 'Authorization: Bearer '$ACCESS_TOKEN
 
@@ -2967,7 +2967,7 @@ or, if you use locally the docker container of the papiNet mock server:
 
 ```text
 $ curl --request GET \
-  --URL http://localhost:3001/orders/1804bcfb-15ae-476a-bc8b-f31bc9f4de62 \
+  --URL http://localhost:3002/orders/1804bcfb-15ae-476a-bc8b-f31bc9f4de62 \
   --header 'Host: papinet.papinet.io' \
   --header 'Authorization: Bearer '$ACCESS_TOKEN
 
@@ -3027,7 +3027,7 @@ or, if you use locally the docker container of the papiNet mock server:
 
 ```text
 $ curl --request GET \
-  --URL http://localhost:3001/orders/1804bcfb-15ae-476a-bc8b-f31bc9f4de62 \
+  --URL http://localhost:3002/orders/1804bcfb-15ae-476a-bc8b-f31bc9f4de62 \
   --header 'Host: papinet.papinet.io' \
   --header 'Authorization: Bearer '$ACCESS_TOKEN
 
@@ -3098,7 +3098,7 @@ or, if you use locally the docker container of the papiNet mock server:
 
 ```text
 $ curl --request GET \
-  --URL http://localhost:3001/orders/1804bcfb-15ae-476a-bc8b-f31bc9f4de62 \
+  --URL http://localhost:3002/orders/1804bcfb-15ae-476a-bc8b-f31bc9f4de62 \
   --header 'Host: papinet.papinet.io' \
   --header 'Authorization: Bearer '$ACCESS_TOKEN
 
@@ -3182,7 +3182,7 @@ or, if you use locally the docker container of the papiNet mock server:
 
 ```text
 $ curl --request GET \
-  --URL http://localhost:3001/orders/1804bcfb-15ae-476a-bc8b-f31bc9f4de62 \
+  --URL http://localhost:3002/orders/1804bcfb-15ae-476a-bc8b-f31bc9f4de62 \
   --header 'Host: papinet.papinet.io' \
   --header 'Authorization: Bearer '$ACCESS_TOKEN
 

--- a/1.1.0/order-status.md
+++ b/1.1.0/order-status.md
@@ -30,7 +30,7 @@ or, if you use locally the docker container of the papiNet mock server:
 ```text
 $ curl --request POST \
   --URL http://localhost:3001/tokens \
-  --header 'X-papiNet-Domain: papinet.papinet.io' \
+  --header 'Host: papinet.papinet.io' \
   --user 'public-36297346:private-ce2d3cf4' \
   --header 'Content-Type: application/x-www-form-urlencoded' \
   --data 'grant_type=client_credentials'
@@ -44,6 +44,33 @@ If all goes well, the _Order Issuer_ will receive a response like this:
   "token_type": "bearer", 
   "expires_in": 3600
 }
+```
+
+In order to re-use the value of the `access_token` in subsequent API requests, it is convenient to save it into an environment variable:
+
+```text
+$ export ACCESS_TOKEN=$(curl --request POST \
+  --URL https://papinet.papinet.io/tokens \
+  --user 'public-36297346:private-ce2d3cf4' \
+  --header 'Content-Type: application/x-www-form-urlencoded' \
+  --data 'grant_type=client_credentials' | jq -r '.access_token')
+```
+
+or, if you use locally the docker container of the papiNet mock server:
+
+```$ export ACCESS_TOKEN=$(curl --request POST \
+  --URL http://localhost:3001/tokens \
+  --header 'Host: papinet.papinet.io' \
+  --user 'public-36297346:private-ce2d3cf4' \
+  --header 'Content-Type: application/x-www-form-urlencoded' \
+  --data 'grant_type=client_credentials' | jq -r '.access_token')
+```
+
+You can easily verify the value of the `ACCESS_TOKEN` environment variable using:
+
+```text
+$ echo $ACCESS_TOKEN
+e6451f7a-e801-4754-adc6-2510c0b2a2aa
 ```
 
 ## Scenarios
@@ -62,7 +89,7 @@ The _Order Issuer_ sends an API request to the _Supplier_ in order to get the li
 ```text
 $ curl --request GET \
   --URL https://papinet.papinet.io/orders?orderStatus=Active \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 or, if you use locally the docker container of the papiNet mock server:
@@ -70,8 +97,8 @@ or, if you use locally the docker container of the papiNet mock server:
 ```text
 $ curl --request GET \
   --URL http://localhost:3001/orders?orderStatus=Active \
-  --header 'X-papiNet-Domain: papinet.papinet.io' \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --header 'Host: papinet.papinet.io' \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 If all goes well, the _Order Issuer_ will receive a response like this:
@@ -117,7 +144,7 @@ The step 1 of the scenario A will simulate the situation in which the (unique) l
 ```text
 $ curl --request GET \
   --URL https://papinet.papinet.io/orders/c51d8903-01d1-485c-96ce-51a9be192207 \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 or, if you use locally the docker container of the papiNet mock server:
@@ -125,8 +152,8 @@ or, if you use locally the docker container of the papiNet mock server:
 ```text
 $ curl --request GET \
   --URL http://localhost:3001/orders/c51d8903-01d1-485c-96ce-51a9be192207 \
-  --header 'X-papiNet-Domain: papinet.papinet.io' \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --header 'Host: papinet.papinet.io' \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 If all goes well, the _Order Issuer_ will receive a response like this:
@@ -165,8 +192,8 @@ The step 2 of the scenario A will simulate the situation in which the _Supplier_
 
 ```text
 $ curl --request GET \
-  --URL https://api.papinet.io/orders/c51d8903-01d1-485c-96ce-51a9be192207 \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --URL https://papinet.papinet.io/orders/c51d8903-01d1-485c-96ce-51a9be192207 \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 or, if you use locally the docker container of the papiNet mock server:
@@ -174,8 +201,8 @@ or, if you use locally the docker container of the papiNet mock server:
 ```text
 $ curl --request GET \
   --URL http://localhost:3001/orders/c51d8903-01d1-485c-96ce-51a9be192207 \
-  --header 'X-papiNet-Domain: papinet.papinet.io' \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --header 'Host: papinet.papinet.io' \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 
 If all goes well, the _Order Issuer_ will receive a response like this:
 
@@ -225,8 +252,8 @@ The step 3 of the scenario A will simulate the situation in which the _Supplier_
 
 ```text
 $ curl --request GET \
-  --URL https://api.papinet.io//orders/c51d8903-01d1-485c-96ce-51a9be192207 \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --URL https://papinet.papinet.io//orders/c51d8903-01d1-485c-96ce-51a9be192207 \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 or, if you use locally the docker container of the papiNet mock server:
@@ -234,8 +261,8 @@ or, if you use locally the docker container of the papiNet mock server:
 ```text
 $ curl --request GET \
   --URL http://localhost:3001/orders/c51d8903-01d1-485c-96ce-51a9be192207 \
-  --header 'X-papiNet-Domain: papinet.papinet.io' \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --header 'Host: papinet.papinet.io' \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 
 If all goes well, the _Order Issuer_ will receive a response like this:
 
@@ -285,8 +312,8 @@ The step 4 of the scenario A will simulate the situation in which the _Supplier_
 
 ```text
 $ curl --request GET \
-  --URL https://api.papinet.io/orders/c51d8903-01d1-485c-96ce-51a9be192207 \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --URL https://papinet.papinet.io/orders/c51d8903-01d1-485c-96ce-51a9be192207 \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 or, if you use locally the docker container of the papiNet mock server:
@@ -294,8 +321,8 @@ or, if you use locally the docker container of the papiNet mock server:
 ```text
 $ curl --request GET \
   --URL http://localhost:3001/orders/c51d8903-01d1-485c-96ce-51a9be192207 \
-  --header 'X-papiNet-Domain: papinet.papinet.io' \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --header 'Host: papinet.papinet.io' \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 
 If all goes well, the _Order Issuer_ will receive a response like this:
 
@@ -357,8 +384,8 @@ The step 5 of the scenario A will simulate the situation in which the _Supplier_
 
 ```text
 $ curl --request GET \
-  --URL https://api.papinet.io/orders/c51d8903-01d1-485c-96ce-51a9be192207 \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --URL https://papinet.papinet.io/orders/c51d8903-01d1-485c-96ce-51a9be192207 \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 or, if you use locally the docker container of the papiNet mock server:
@@ -366,8 +393,8 @@ or, if you use locally the docker container of the papiNet mock server:
 ```text
 $ curl --request GET \
   --URL http://localhost:3001/orders/c51d8903-01d1-485c-96ce-51a9be192207 \
-  --header 'X-papiNet-Domain: papinet.papinet.io' \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --header 'Host: papinet.papinet.io' \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 
 If all goes well, the _Order Issuer_ will receive a response like this:
 
@@ -441,8 +468,8 @@ The step 6 of the scenario A will simulate the situation in which the _Supplier_
 
 ```text
 $ curl --request GET \
-  --URL https://api.papinet.io/orders/c51d8903-01d1-485c-96ce-51a9be192207 \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --URL https://papinet.papinet.io/orders/c51d8903-01d1-485c-96ce-51a9be192207 \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 or, if you use locally the docker container of the papiNet mock server:
@@ -450,8 +477,8 @@ or, if you use locally the docker container of the papiNet mock server:
 ```text
 $ curl --request GET \
   --URL http://localhost:3001/orders/c51d8903-01d1-485c-96ce-51a9be192207 \
-  --header 'X-papiNet-Domain: papinet.papinet.io' \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --header 'Host: papinet.papinet.io' \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 
 If all goes well, the _Order Issuer_ will receive a response like this:
 
@@ -532,7 +559,7 @@ The _Order Issuer_ sends an API request to the _Supplier_ in order to get the li
 ```text
 $ curl --request GET \
   --URL https://papinet.papinet.io/orders?orderStatus=Active \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 or, if you use locally the docker container of the papiNet mock server:
@@ -540,8 +567,8 @@ or, if you use locally the docker container of the papiNet mock server:
 ```text
 $ curl --request GET \
   --URL http://localhost:3001/orders?orderStatus=Active \
-  --header 'X-papiNet-Domain: papinet.papinet.io' \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --header 'Host: papinet.papinet.io' \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 
 If all goes well, the _Order Issuer_ will receive a response like this:
 
@@ -584,7 +611,7 @@ The step 1 of the scenario B will simulate the situation in which the (unique) l
 ```text
 $ curl --request GET \
   --URL https://papinet.papinet.io/orders/778fe5cb-f7ac-4493-b492-25fe98df67c4 \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 or, if you use locally the docker container of the papiNet mock server:
@@ -592,8 +619,8 @@ or, if you use locally the docker container of the papiNet mock server:
 ```text
 $ curl --request GET \
   --URL http://localhost:3001/orders/778fe5cb-f7ac-4493-b492-25fe98df67c4 \
-  --header 'X-papiNet-Domain: papinet.papinet.io' \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --header 'Host: papinet.papinet.io' \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 
 
 If all goes well, the _Order Issuer_ will receive a response like this:
@@ -633,7 +660,7 @@ The step 2 of the scenario B will simulate the situation in which the _Supplier_
 ```text
 $ curl --request GET \
   --URL https://papinet.papinet.io/orders/778fe5cb-f7ac-4493-b492-25fe98df67c4 \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 or, if you use locally the docker container of the papiNet mock server:
@@ -641,8 +668,8 @@ or, if you use locally the docker container of the papiNet mock server:
 ```text
 $ curl --request GET \
   --URL http://localhost:3001/orders/778fe5cb-f7ac-4493-b492-25fe98df67c4 \
-  --header 'X-papiNet-Domain: papinet.papinet.io' \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --header 'Host: papinet.papinet.io' \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 
 If all goes well, the _Order Issuer_ will receive a response like this:
 
@@ -693,7 +720,7 @@ The step 3 of the scenario B will simulate the situation in which the _Supplier_
 ```text
 $ curl --request GET \
   --URL https://papinet.papinet.io/orders/778fe5cb-f7ac-4493-b492-25fe98df67c4 \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 or, if you use locally the docker container of the papiNet mock server:
@@ -701,8 +728,8 @@ or, if you use locally the docker container of the papiNet mock server:
 ```text
 $ curl --request GET \
   --URL http://localhost:3001/orders/778fe5cb-f7ac-4493-b492-25fe98df67c4 \
-  --header 'X-papiNet-Domain: papinet.papinet.io' \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --header 'Host: papinet.papinet.io' \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 
 If all goes well, the _Order Issuer_ will receive a response like this:
 
@@ -753,7 +780,7 @@ The step 4 of the scenario B will simulate the situation in which the _Supplier_
 ```text
 $ curl --request GET \
   --URL https://papinet.papinet.io/orders/778fe5cb-f7ac-4493-b492-25fe98df67c4 \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 or, if you use locally the docker container of the papiNet mock server:
@@ -761,8 +788,8 @@ or, if you use locally the docker container of the papiNet mock server:
 ```text
 $ curl --request GET \
   --URL http://localhost:3001/orders/778fe5cb-f7ac-4493-b492-25fe98df67c4 \
-  --header 'X-papiNet-Domain: papinet.papinet.io' \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --header 'Host: papinet.papinet.io' \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 
 If all goes well, the _Order Issuer_ will receive a response like this:
 
@@ -825,7 +852,7 @@ The step 5 of the scenario B will simulate the situation in which the _Supplier_
 ```text
 $ curl --request GET \
   --URL https://papinet.papinet.io/orders/778fe5cb-f7ac-4493-b492-25fe98df67c4 \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 or, if you use locally the docker container of the papiNet mock server:
@@ -833,8 +860,8 @@ or, if you use locally the docker container of the papiNet mock server:
 ```text
 $ curl --request GET \
   --URL http://localhost:3001/orders/778fe5cb-f7ac-4493-b492-25fe98df67c4 \
-  --header 'X-papiNet-Domain: papinet.papinet.io' \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --header 'Host: papinet.papinet.io' \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 
 If all goes well, the _Order Issuer_ will receive a response like this:
 
@@ -897,7 +924,7 @@ The step 6 of the scenario A will simulate the situation in which the _Supplier_
 ```text
 $ curl --request GET \
   --URL https://papinet.papinet.io/orders/778fe5cb-f7ac-4493-b492-25fe98df67c4 \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 or, if you use locally the docker container of the papiNet mock server:
@@ -905,8 +932,8 @@ or, if you use locally the docker container of the papiNet mock server:
 ```text
 $ curl --request GET \
   --URL http://localhost:3001/orders/778fe5cb-f7ac-4493-b492-25fe98df67c4 \
-  --header 'X-papiNet-Domain: papinet.papinet.io' \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --header 'Host: papinet.papinet.io' \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 
 If all goes well, the _Order Issuer_ will receive a response like this:
 
@@ -969,7 +996,7 @@ The step 7 of the scenario A will simulate the situation in which the _Supplier_
 ```text
 $ curl --request GET \
   --URL https://papinet.papinet.io/orders/778fe5cb-f7ac-4493-b492-25fe98df67c4 \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 or, if you use locally the docker container of the papiNet mock server:
@@ -977,8 +1004,8 @@ or, if you use locally the docker container of the papiNet mock server:
 ```text
 $ curl --request GET \
   --URL http://localhost:3001/orders/778fe5cb-f7ac-4493-b492-25fe98df67c4 \
-  --header 'X-papiNet-Domain: papinet.papinet.io' \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --header 'Host: papinet.papinet.io' \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 
 If all goes well, the _Order Issuer_ will receive a response like this:
 
@@ -1053,7 +1080,7 @@ The step 8 of the scenario A will simulate the situation in which the _Supplier_
 ```text
 $ curl --request GET \
   --URL https://papinet.papinet.io/orders/778fe5cb-f7ac-4493-b492-25fe98df67c4 \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 or, if you use locally the docker container of the papiNet mock server:
@@ -1061,8 +1088,8 @@ or, if you use locally the docker container of the papiNet mock server:
 ```text
 $ curl --request GET \
   --URL http://localhost:3001/orders/778fe5cb-f7ac-4493-b492-25fe98df67c4 \
-  --header 'X-papiNet-Domain: papinet.papinet.io' \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --header 'Host: papinet.papinet.io' \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 
 If all goes well, the _Order Issuer_ will receive a response like this:
 
@@ -1143,7 +1170,7 @@ The _Order Issuer_ sends an API request to the _Supplier_ in order to get the li
 ```text
 $ curl --request GET \
   --URL https://papinet.papinet.io/orders?orderStatus=Active \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 or, if you use locally the docker container of the papiNet mock server:
@@ -1151,8 +1178,8 @@ or, if you use locally the docker container of the papiNet mock server:
 ```text
 $ curl --request GET \
   --URL http://localhost:3001/orders?orderStatus=Active \
-  --header 'X-papiNet-Domain: papinet.papinet.io' \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --header 'Host: papinet.papinet.io' \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 
 If all goes well, the _Order Issuer_ will receive a response like this:
 
@@ -1191,7 +1218,7 @@ We have prepared the scenario A on the order `1003`, so we need to get the "next
 ```text
 $ curl --request GET \
   --URL 'https://papinet.papinet.io/orders?orderStatus=Active&offset=2&limit=2' \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 or, if you use locally the docker container of the papiNet mock server:
@@ -1199,8 +1226,8 @@ or, if you use locally the docker container of the papiNet mock server:
 ```text
 $ curl --request GET \
   --URL http://localhost:3001/orders?orderStatus=Active&offset=2&limit=2 \
-  --header 'X-papiNet-Domain: papinet.papinet.io' \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --header 'Host: papinet.papinet.io' \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 
 If all goes well, the _Order Issuer_ will receive a response like this:
 
@@ -1241,7 +1268,7 @@ The step 1 of the scenario C will simulate the situation in which the (unique) l
 ```text
 $ curl --request GET \
   --URL https://papinet.papinet.io/orders/c898aa54-8ebb-40ab-a0b9-3d979e082a9e \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 or, if you use locally the docker container of the papiNet mock server:
@@ -1249,8 +1276,8 @@ or, if you use locally the docker container of the papiNet mock server:
 ```text
 $ curl --request GET \
   --URL http://localhost:3001/orders/c898aa54-8ebb-40ab-a0b9-3d979e082a9e \
-  --header 'X-papiNet-Domain: papinet.papinet.io' \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --header 'Host: papinet.papinet.io' \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 
 If all goes well, the _Order Issuer_ will receive a response like this:
 
@@ -1289,7 +1316,7 @@ The step 2 of the scenario C will simulate the situation in which the _Supplier_
 ```text
 $ curl --request GET \
   --URL https://papinet.papinet.io/orders/c898aa54-8ebb-40ab-a0b9-3d979e082a9e \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 or, if you use locally the docker container of the papiNet mock server:
@@ -1297,8 +1324,8 @@ or, if you use locally the docker container of the papiNet mock server:
 ```text
 $ curl --request GET \
   --URL http://localhost:3001/orders/c898aa54-8ebb-40ab-a0b9-3d979e082a9e \
-  --header 'X-papiNet-Domain: papinet.papinet.io' \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --header 'Host: papinet.papinet.io' \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 
 If all goes well, the _Order Issuer_ will receive a response like this:
 
@@ -1349,7 +1376,7 @@ The step 3 of the scenario C will simulate the situation in which the _Supplier_
 ```text
 $ curl --request GET \
   --URL https://papinet.papinet.io/orders/c898aa54-8ebb-40ab-a0b9-3d979e082a9e \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 or, if you use locally the docker container of the papiNet mock server:
@@ -1357,8 +1384,8 @@ or, if you use locally the docker container of the papiNet mock server:
 ```text
 $ curl --request GET \
   --URL http://localhost:3001/orders/c898aa54-8ebb-40ab-a0b9-3d979e082a9e \
-  --header 'X-papiNet-Domain: papinet.papinet.io' \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --header 'Host: papinet.papinet.io' \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 
 If all goes well, the _Order Issuer_ will receive a response like this:
 
@@ -1409,7 +1436,7 @@ The step 4 of the scenario C will simulate the situation in which the _Supplier_
 ```text
 $ curl --request GET \
   --URL https://papinet.papinet.io/orders/c898aa54-8ebb-40ab-a0b9-3d979e082a9e \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 or, if you use locally the docker container of the papiNet mock server:
@@ -1417,8 +1444,8 @@ or, if you use locally the docker container of the papiNet mock server:
 ```text
 $ curl --request GET \
   --URL http://localhost:3001/orders/c898aa54-8ebb-40ab-a0b9-3d979e082a9e \
-  --header 'X-papiNet-Domain: papinet.papinet.io' \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --header 'Host: papinet.papinet.io' \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 
 If all goes well, the _Order Issuer_ will receive a response like this:
 
@@ -1481,7 +1508,7 @@ The step 5 of the scenario C will simulate the situation in which the _Supplier_
 ```text
 $ curl --request GET \
   --URL https://papinet.papinet.io/orders/c898aa54-8ebb-40ab-a0b9-3d979e082a9e \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 or, if you use locally the docker container of the papiNet mock server:
@@ -1489,8 +1516,8 @@ or, if you use locally the docker container of the papiNet mock server:
 ```text
 $ curl --request GET \
   --URL http://localhost:3001/orders/c898aa54-8ebb-40ab-a0b9-3d979e082a9e \
-  --header 'X-papiNet-Domain: papinet.papinet.io' \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --header 'Host: papinet.papinet.io' \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 
 If all goes well, the _Order Issuer_ will receive a response like this:
 
@@ -1565,7 +1592,7 @@ The step 6 of the scenario C will simulate the situation in which the _Supplier_
 ```text
 $ curl --request GET \
   --URL https://papinet.papinet.io/orders/c898aa54-8ebb-40ab-a0b9-3d979e082a9e \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 or, if you use locally the docker container of the papiNet mock server:
@@ -1573,8 +1600,8 @@ or, if you use locally the docker container of the papiNet mock server:
 ```text
 $ curl --request GET \
   --URL http://localhost:3001/orders/c898aa54-8ebb-40ab-a0b9-3d979e082a9e \
-  --header 'X-papiNet-Domain: papinet.papinet.io' \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --header 'Host: papinet.papinet.io' \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 
 If all goes well, the _Order Issuer_ will receive a response like this:
 
@@ -1649,7 +1676,7 @@ The step 7 of the scenario C will simulate the situation in which the _Supplier_
 ```text
 $ curl --request GET \
   --URL https://papinet.papinet.io/orders/c898aa54-8ebb-40ab-a0b9-3d979e082a9e \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 or, if you use locally the docker container of the papiNet mock server:
@@ -1657,8 +1684,8 @@ or, if you use locally the docker container of the papiNet mock server:
 ```text
 $ curl --request GET \
   --URL http://localhost:3001/orders/c898aa54-8ebb-40ab-a0b9-3d979e082a9e \
-  --header 'X-papiNet-Domain: papinet.papinet.io' \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --header 'Host: papinet.papinet.io' \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 
 If all goes well, the _Order Issuer_ will receive a response like this:
 
@@ -1740,8 +1767,8 @@ The step 1 of the scenario D will simulate the situation in which the (unique) l
 
 ```text
 $ curl --request GET \
-  --URL https://api.papinet.io/orders/fb441640-e40b-4d91-8930-61ebf981da63 \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --URL https://papinet.papinet.io/orders/fb441640-e40b-4d91-8930-61ebf981da63 \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 or, if you use locally the docker container of the papiNet mock server:
@@ -1749,8 +1776,8 @@ or, if you use locally the docker container of the papiNet mock server:
 ```text
 $ curl --request GET \
   --URL http://localhost:3001/orders/fb441640-e40b-4d91-8930-61ebf981da63 \
-  --header 'X-papiNet-Domain: papinet.papinet.io' \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --header 'Host: papinet.papinet.io' \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 
 If all goes well, the _Order Issuer_ will receive a response like this:
 
@@ -1788,8 +1815,8 @@ The step 2 of the scenario D will simulate the situation in which the _Supplier_
 
 ```text
 $ curl --request GET \
-  --URL https://api.papinet.io/orders/fb441640-e40b-4d91-8930-61ebf981da63 \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --URL https://papinet.papinet.io/orders/fb441640-e40b-4d91-8930-61ebf981da63 \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 or, if you use locally the docker container of the papiNet mock server:
@@ -1797,8 +1824,8 @@ or, if you use locally the docker container of the papiNet mock server:
 ```text
 $ curl --request GET \
   --URL http://localhost:3001/orders/fb441640-e40b-4d91-8930-61ebf981da63 \
-  --header 'X-papiNet-Domain: papinet.papinet.io' \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --header 'Host: papinet.papinet.io' \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 
 If all goes well, the _Order Issuer_ will receive a response like this:
 
@@ -1848,8 +1875,8 @@ The step 3 of the scenario D will simulate the situation in which the _Supplier_
 
 ```text
 $ curl --request GET \
-  --URL https://api.papinet.io/orders/fb441640-e40b-4d91-8930-61ebf981da63 \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --URL https://papinet.papinet.io/orders/fb441640-e40b-4d91-8930-61ebf981da63 \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 or, if you use locally the docker container of the papiNet mock server:
@@ -1857,8 +1884,8 @@ or, if you use locally the docker container of the papiNet mock server:
 ```text
 $ curl --request GET \
   --URL http://localhost:3001/orders/fb441640-e40b-4d91-8930-61ebf981da63 \
-  --header 'X-papiNet-Domain: papinet.papinet.io' \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --header 'Host: papinet.papinet.io' \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 
 If all goes well, the _Order Issuer_ will receive a response like this:
 
@@ -1908,8 +1935,8 @@ The step 4 of the scenario D will simulate the situation in which the _Supplier_
 
 ```text
 $ curl --request GET \
-  --URL https://api.papinet.io/orders/fb441640-e40b-4d91-8930-61ebf981da63 \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --URL https://papinet.papinet.io/orders/fb441640-e40b-4d91-8930-61ebf981da63 \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 or, if you use locally the docker container of the papiNet mock server:
@@ -1917,8 +1944,8 @@ or, if you use locally the docker container of the papiNet mock server:
 ```text
 $ curl --request GET \
   --URL http://localhost:3001/orders/fb441640-e40b-4d91-8930-61ebf981da63 \
-  --header 'X-papiNet-Domain: papinet.papinet.io' \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --header 'Host: papinet.papinet.io' \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 
 If all goes well, the _Order Issuer_ will receive a response like this:
 
@@ -1980,8 +2007,8 @@ The step 5 of the scenario D will simulate the situation in which the _Supplier_
 
 ```text
 $ curl --request GET \
-  --URL https://api.papinet.io/orders/fb441640-e40b-4d91-8930-61ebf981da63 \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --URL https://papinet.papinet.io/orders/fb441640-e40b-4d91-8930-61ebf981da63 \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 or, if you use locally the docker container of the papiNet mock server:
@@ -1989,8 +2016,8 @@ or, if you use locally the docker container of the papiNet mock server:
 ```text
 $ curl --request GET \
   --URL http://localhost:3001/orders/fb441640-e40b-4d91-8930-61ebf981da63 \
-  --header 'X-papiNet-Domain: papinet.papinet.io' \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --header 'Host: papinet.papinet.io' \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 
 If all goes well, the _Order Issuer_ will receive a response like this:
 
@@ -2064,8 +2091,8 @@ The step 6 of the scenario D will simulate the situation in which the _Supplier_
 
 ```text
 $ curl --request GET \
-  --URL https://api.papinet.io/orders/fb441640-e40b-4d91-8930-61ebf981da63 \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --URL https://papinet.papinet.io/orders/fb441640-e40b-4d91-8930-61ebf981da63 \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 or, if you use locally the docker container of the papiNet mock server:
@@ -2073,8 +2100,8 @@ or, if you use locally the docker container of the papiNet mock server:
 ```text
 $ curl --request GET \
   --URL http://localhost:3001/orders/fb441640-e40b-4d91-8930-61ebf981da63 \
-  --header 'X-papiNet-Domain: papinet.papinet.io' \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --header 'Host: papinet.papinet.io' \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 
 If all goes well, the _Order Issuer_ will receive a response like this:
 
@@ -2148,8 +2175,8 @@ The step 6 of the scenario D will simulate the situation in which the _Supplier_
 
 ```text
 $ curl --request GET \
-  --URL https://api.papinet.io/orders/fb441640-e40b-4d91-8930-61ebf981da63 \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --URL https://papinet.papinet.io/orders/fb441640-e40b-4d91-8930-61ebf981da63 \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 or, if you use locally the docker container of the papiNet mock server:
@@ -2157,8 +2184,8 @@ or, if you use locally the docker container of the papiNet mock server:
 ```text
 $ curl --request GET \
   --URL http://localhost:3001/orders/fb441640-e40b-4d91-8930-61ebf981da63 \
-  --header 'X-papiNet-Domain: papinet.papinet.io' \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --header 'Host: papinet.papinet.io' \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 
 If all goes well, the _Order Issuer_ will receive a response like this:
 
@@ -2232,8 +2259,8 @@ The step 8 of the scenario D will simulate the situation in which the _Supplier_
 
 ```text
 $ curl --request GET \
-  --URL https://api.papinet.io/orders/fb441640-e40b-4d91-8930-61ebf981da63 \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --URL https://papinet.papinet.io/orders/fb441640-e40b-4d91-8930-61ebf981da63 \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 or, if you use locally the docker container of the papiNet mock server:
@@ -2241,8 +2268,8 @@ or, if you use locally the docker container of the papiNet mock server:
 ```text
 $ curl --request GET \
   --URL http://localhost:3001/orders/fb441640-e40b-4d91-8930-61ebf981da63 \
-  --header 'X-papiNet-Domain: papinet.papinet.io' \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --header 'Host: papinet.papinet.io' \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 
 If all goes well, the _Order Issuer_ will receive a response like this:
 
@@ -2316,8 +2343,8 @@ The step 9 of the scenario D will simulate the situation in which the _Supplier_
 
 ```text
 $ curl --request GET \
-  --URL https://api.papinet.io/orders/fb441640-e40b-4d91-8930-61ebf981da63 \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --URL https://papinet.papinet.io/orders/fb441640-e40b-4d91-8930-61ebf981da63 \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 or, if you use locally the docker container of the papiNet mock server:
@@ -2325,8 +2352,8 @@ or, if you use locally the docker container of the papiNet mock server:
 ```text
 $ curl --request GET \
   --URL http://localhost:3001/orders/fb441640-e40b-4d91-8930-61ebf981da63 \
-  --header 'X-papiNet-Domain: papinet.papinet.io' \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --header 'Host: papinet.papinet.io' \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 
 If all goes well, the _Order Issuer_ will receive a response like this:
 
@@ -2408,8 +2435,8 @@ The step 1 of the scenario D will simulate the situation in which the (unique) l
 
 ```text
 $ curl --request GET \
-  --URL https://api.papinet.io/orders/12e8667f-14ed-49e6-9610-dc58dee95560 \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --URL https://papinet.papinet.io/orders/12e8667f-14ed-49e6-9610-dc58dee95560 \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 or, if you use locally the docker container of the papiNet mock server:
@@ -2417,8 +2444,8 @@ or, if you use locally the docker container of the papiNet mock server:
 ```text
 $ curl --request GET \
   --URL http://localhost:3001/orders/12e8667f-14ed-49e6-9610-dc58dee95560 \
-  --header 'X-papiNet-Domain: papinet.papinet.io' \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --header 'Host: papinet.papinet.io' \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 
 If all goes well, the _Order Issuer_ will receive a response like this:
 
@@ -2456,8 +2483,8 @@ The step 2 of the scenario D will simulate the situation in which the _Supplier_
 
 ```text
 $ curl --request GET \
-  --URL https://api.papinet.io/orders/12e8667f-14ed-49e6-9610-dc58dee95560 \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --URL https://papinet.papinet.io/orders/12e8667f-14ed-49e6-9610-dc58dee95560 \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 or, if you use locally the docker container of the papiNet mock server:
@@ -2465,8 +2492,8 @@ or, if you use locally the docker container of the papiNet mock server:
 ```text
 $ curl --request GET \
   --URL http://localhost:3001/orders/12e8667f-14ed-49e6-9610-dc58dee95560 \
-  --header 'X-papiNet-Domain: papinet.papinet.io' \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --header 'Host: papinet.papinet.io' \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 
 If all goes well, the _Order Issuer_ will receive a response like this:
 
@@ -2516,8 +2543,8 @@ The step 3 of the scenario D will simulate the situation in which the _Supplier_
 
 ```text
 $ curl --request GET \
-  --URL https://api.papinet.io/orders/12e8667f-14ed-49e6-9610-dc58dee95560 \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --URL https://papinet.papinet.io/orders/12e8667f-14ed-49e6-9610-dc58dee95560 \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 or, if you use locally the docker container of the papiNet mock server:
@@ -2525,8 +2552,8 @@ or, if you use locally the docker container of the papiNet mock server:
 ```text
 $ curl --request GET \
   --URL http://localhost:3001/orders/12e8667f-14ed-49e6-9610-dc58dee95560 \
-  --header 'X-papiNet-Domain: papinet.papinet.io' \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --header 'Host: papinet.papinet.io' \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 
 If all goes well, the _Order Issuer_ will receive a response like this:
 
@@ -2576,8 +2603,8 @@ The step 4 of the scenario E will simulate the situation in which the _Supplier_
 
 ```text
 $ curl --request GET \
-  --URL https://api.papinet.io/orders/12e8667f-14ed-49e6-9610-dc58dee95560 \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --URL https://papinet.papinet.io/orders/12e8667f-14ed-49e6-9610-dc58dee95560 \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 or, if you use locally the docker container of the papiNet mock server:
@@ -2585,8 +2612,8 @@ or, if you use locally the docker container of the papiNet mock server:
 ```text
 $ curl --request GET \
   --URL http://localhost:3001/orders/12e8667f-14ed-49e6-9610-dc58dee95560 \
-  --header 'X-papiNet-Domain: papinet.papinet.io' \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --header 'Host: papinet.papinet.io' \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 
 If all goes well, the _Order Issuer_ will receive a response like this:
 
@@ -2648,8 +2675,8 @@ The step 5 of the scenario E will simulate the situation in which the _Supplier_
 
 ```text
 $ curl --request GET \
-  --URL https://api.papinet.io/orders/12e8667f-14ed-49e6-9610-dc58dee95560 \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --URL https://papinet.papinet.io/orders/12e8667f-14ed-49e6-9610-dc58dee95560 \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 or, if you use locally the docker container of the papiNet mock server:
@@ -2657,8 +2684,8 @@ or, if you use locally the docker container of the papiNet mock server:
 ```text
 $ curl --request GET \
   --URL http://localhost:3001/orders/12e8667f-14ed-49e6-9610-dc58dee95560 \
-  --header 'X-papiNet-Domain: papinet.papinet.io' \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --header 'Host: papinet.papinet.io' \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 
 If all goes well, the _Order Issuer_ will receive a response like this:
 
@@ -2732,8 +2759,8 @@ The step 6 of the scenario E will simulate the situation in which the _Supplier_
 
 ```text
 $ curl --request GET \
-  --URL https://api.papinet.io/orders/12e8667f-14ed-49e6-9610-dc58dee95560 \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --URL https://papinet.papinet.io/orders/12e8667f-14ed-49e6-9610-dc58dee95560 \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 or, if you use locally the docker container of the papiNet mock server:
@@ -2741,8 +2768,8 @@ or, if you use locally the docker container of the papiNet mock server:
 ```text
 $ curl --request GET \
   --URL http://localhost:3001/orders/12e8667f-14ed-49e6-9610-dc58dee95560 \
-  --header 'X-papiNet-Domain: papinet.papinet.io' \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --header 'Host: papinet.papinet.io' \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 
 If all goes well, the _Order Issuer_ will receive a response like this:
 
@@ -2824,8 +2851,8 @@ The step 1 of the scenario D will simulate the situation in which the (unique) l
 
 ```text
 $ curl --request GET \
-  --URL https://api.papinet.io/orders/1804bcfb-15ae-476a-bc8b-f31bc9f4de62 \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --URL https://papinet.papinet.io/orders/1804bcfb-15ae-476a-bc8b-f31bc9f4de62 \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 or, if you use locally the docker container of the papiNet mock server:
@@ -2833,8 +2860,8 @@ or, if you use locally the docker container of the papiNet mock server:
 ```text
 $ curl --request GET \
   --URL http://localhost:3001/orders/1804bcfb-15ae-476a-bc8b-f31bc9f4de62 \
-  --header 'X-papiNet-Domain: papinet.papinet.io' \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --header 'Host: papinet.papinet.io' \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 
 If all goes well, the _Order Issuer_ will receive a response like this:
 
@@ -2872,8 +2899,8 @@ The step 2 of the scenario D will simulate the situation in which the _Supplier_
 
 ```text
 $ curl --request GET \
-  --URL https://api.papinet.io/orders/1804bcfb-15ae-476a-bc8b-f31bc9f4de62 \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --URL https://papinet.papinet.io/orders/1804bcfb-15ae-476a-bc8b-f31bc9f4de62 \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 or, if you use locally the docker container of the papiNet mock server:
@@ -2881,8 +2908,8 @@ or, if you use locally the docker container of the papiNet mock server:
 ```text
 $ curl --request GET \
   --URL http://localhost:3001/orders/1804bcfb-15ae-476a-bc8b-f31bc9f4de62 \
-  --header 'X-papiNet-Domain: papinet.papinet.io' \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --header 'Host: papinet.papinet.io' \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 
 If all goes well, the _Order Issuer_ will receive a response like this:
 
@@ -2932,8 +2959,8 @@ The step 3 of the scenario D will simulate the situation in which the _Supplier_
 
 ```text
 $ curl --request GET \
-  --URL https://api.papinet.io/orders/1804bcfb-15ae-476a-bc8b-f31bc9f4de62 \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --URL https://papinet.papinet.io/orders/1804bcfb-15ae-476a-bc8b-f31bc9f4de62 \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 or, if you use locally the docker container of the papiNet mock server:
@@ -2941,8 +2968,8 @@ or, if you use locally the docker container of the papiNet mock server:
 ```text
 $ curl --request GET \
   --URL http://localhost:3001/orders/1804bcfb-15ae-476a-bc8b-f31bc9f4de62 \
-  --header 'X-papiNet-Domain: papinet.papinet.io' \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --header 'Host: papinet.papinet.io' \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 
 If all goes well, the _Order Issuer_ will receive a response like this:
 
@@ -2992,8 +3019,8 @@ The step 4 of the scenario E will simulate the situation in which the _Supplier_
 
 ```text
 $ curl --request GET \
-  --URL https://api.papinet.io/orders/1804bcfb-15ae-476a-bc8b-f31bc9f4de62 \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --URL https://papinet.papinet.io/orders/1804bcfb-15ae-476a-bc8b-f31bc9f4de62 \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 or, if you use locally the docker container of the papiNet mock server:
@@ -3001,8 +3028,8 @@ or, if you use locally the docker container of the papiNet mock server:
 ```text
 $ curl --request GET \
   --URL http://localhost:3001/orders/1804bcfb-15ae-476a-bc8b-f31bc9f4de62 \
-  --header 'X-papiNet-Domain: papinet.papinet.io' \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --header 'Host: papinet.papinet.io' \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 
 If all goes well, the _Order Issuer_ will receive a response like this:
 
@@ -3063,8 +3090,8 @@ The step 5 of the scenario E will simulate the situation in which the _Supplier_
 
 ```text
 $ curl --request GET \
-  --URL https://api.papinet.io/orders/1804bcfb-15ae-476a-bc8b-f31bc9f4de62 \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --URL https://papinet.papinet.io/orders/1804bcfb-15ae-476a-bc8b-f31bc9f4de62 \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 or, if you use locally the docker container of the papiNet mock server:
@@ -3072,8 +3099,8 @@ or, if you use locally the docker container of the papiNet mock server:
 ```text
 $ curl --request GET \
   --URL http://localhost:3001/orders/1804bcfb-15ae-476a-bc8b-f31bc9f4de62 \
-  --header 'X-papiNet-Domain: papinet.papinet.io' \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --header 'Host: papinet.papinet.io' \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 
 If all goes well, the _Order Issuer_ will receive a response like this:
 
@@ -3147,8 +3174,8 @@ The step 6 of the scenario E will simulate the situation in which the _Supplier_
 
 ```text
 $ curl --request GET \
-  --URL https://api.papinet.io/orders/1804bcfb-15ae-476a-bc8b-f31bc9f4de62 \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --URL https://papinet.papinet.io/orders/1804bcfb-15ae-476a-bc8b-f31bc9f4de62 \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 or, if you use locally the docker container of the papiNet mock server:
@@ -3156,8 +3183,8 @@ or, if you use locally the docker container of the papiNet mock server:
 ```text
 $ curl --request GET \
   --URL http://localhost:3001/orders/1804bcfb-15ae-476a-bc8b-f31bc9f4de62 \
-  --header 'X-papiNet-Domain: papinet.papinet.io' \
-  --header 'Authorization: Bearer ef1bee66-8607-4f32-854c-76ff44763ab7'
+  --header 'Host: papinet.papinet.io' \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 
 If all goes well, the _Order Issuer_ will receive a response like this:
 

--- a/1.1.0/shipment-status.md
+++ b/1.1.0/shipment-status.md
@@ -64,7 +64,7 @@ or, if you use locally the docker container of the papiNet mock server:
 ```text
 $ curl --request POST \
   --URL http://localhost:3001/tokens \
-  --header 'X-papiNet-Domain: papinet.road.papinet.io' \
+  --header 'Host: papinet.road.papinet.io' \
   --user 'public-36297346:private-ce2d3cf4' \
   --header 'Content-Type: application/x-www-form-urlencoded' \
   --data 'grant_type=client_credentials'
@@ -80,6 +80,33 @@ If all goes well, the company **Fast** will receive a response like this:
 }
 ```
 
+In order to re-use the value of the `access_token` in subsequent API requests, it is convenient to save it into an environment variable:
+
+```text
+$ export ACCESS_TOKEN=$(curl --request POST \
+  --URL https://papinet.road.papinet.io/tokens \
+  --user 'public-36297346:private-ce2d3cf4' \
+  --header 'Content-Type: application/x-www-form-urlencoded' \
+  --data 'grant_type=client_credentials' | jq -r '.access_token')
+```
+
+or, if you use locally the docker container of the papiNet mock server:
+
+```$ export ACCESS_TOKEN=$(curl --request POST \
+  --URL http://localhost:3001/tokens \
+  --header 'Host: papinet.road.papinet.io' \
+  --user 'public-36297346:private-ce2d3cf4' \
+  --header 'Content-Type: application/x-www-form-urlencoded' \
+  --data 'grant_type=client_credentials' | jq -r '.access_token')
+```
+
+You can easily verify the value of the `ACCESS_TOKEN` environment variable using:
+
+```text
+$ echo $ACCESS_TOKEN
+9b875e37-42ec-4fb0-bced-0fb6724d4767
+```
+
 #### Step 2 of Scenario A - List of Shipments
 
 The company **Fast**, being a _Forwarder_, sends an API request to the company **Road**, being a _Carrier_, in order to get the list of all its _Active shipments_:
@@ -87,7 +114,7 @@ The company **Fast**, being a _Forwarder_, sends an API request to the company *
 ```text
 $ curl --request GET \
   --URL https://papinet.road.papinet.io/shipments?shipmentStatus=Active \
-  --header 'Authorization: Bearer efe30794-3f53-40c4-a5dc-77c475a8561d'
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 or, if you use locally the docker container of the papiNet mock server:
@@ -95,8 +122,8 @@ or, if you use locally the docker container of the papiNet mock server:
 ```text
 $ curl --request GET \
   --URL http://localhost:3001/shipments?shipmentStatus=Active \
-  --header 'X-papiNet-Domain: papinet.road.papinet.io' \
-  --header 'Authorization: Bearer efe30794-3f53-40c4-a5dc-77c475a8561d'
+  --header 'Host: papinet.road.papinet.io' \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 If all goes well, the company **Fast** will receive a response like this:
@@ -160,7 +187,7 @@ The company **Fast**, being a _Forwarder_, sends an API request to the company *
 ```text
 $ curl --request GET \
   --URL https://papinet.road.papinet.io/shipments/c51d8903-01d1-485c-96ce-51a9be192207 \
-  --header 'Authorization: Bearer efe30794-3f53-40c4-a5dc-77c475a8561d'
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 or, if you use locally the docker container of the papiNet mock server:
@@ -168,8 +195,8 @@ or, if you use locally the docker container of the papiNet mock server:
 ```text
 $ curl --request GET \
   --URL http://localhost:3001/shipments/c51d8903-01d1-485c-96ce-51a9be192207 \
-  --header 'X-papiNet-Domain: papinet.road.papinet.io' \
-  --header 'Authorization: Bearer efe30794-3f53-40c4-a5dc-77c475a8561d'
+  --header 'Host: papinet.road.papinet.io' \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 If all goes well, the company **Fast** will receive a response like this:
@@ -209,7 +236,7 @@ The step 4 of the scenario A will simulate the situation in which the company **
 ```text
 $ curl --request GET \
   --URL https://papinet.road.papinet.io/shipments/c51d8903-01d1-485c-96ce-51a9be192207 \
-  --header 'Authorization: Bearer efe30794-3f53-40c4-a5dc-77c475a8561d'
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 or, if you use locally the docker container of the papiNet mock server:
@@ -217,8 +244,8 @@ or, if you use locally the docker container of the papiNet mock server:
 ```text
 $ curl --request GET \
   --URL http://localhost:3001/shipments/c51d8903-01d1-485c-96ce-51a9be192207 \
-  --header 'X-papiNet-Domain: papinet.road.papinet.io' \
-  --header 'Authorization: Bearer efe30794-3f53-40c4-a5dc-77c475a8561d'
+  --header 'Host: papinet.road.papinet.io' \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 If all goes well, the company **Fast** will receive a response like this:
@@ -258,7 +285,7 @@ The step 5 of the scenario A will simulate the situation in which the company **
 ```text
 $ curl --request GET \
   --URL https://papinet.road.papinet.io/shipments/c51d8903-01d1-485c-96ce-51a9be192207 \
-  --header 'Authorization: Bearer efe30794-3f53-40c4-a5dc-77c475a8561d'
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 or, if you use locally the docker container of the papiNet mock server:
@@ -266,8 +293,8 @@ or, if you use locally the docker container of the papiNet mock server:
 ```text
 $ curl --request GET \
   --URL http://localhost:3001/shipments/c51d8903-01d1-485c-96ce-51a9be192207 \
-  --header 'X-papiNet-Domain: papinet.road.papinet.io' \
-  --header 'Authorization: Bearer efe30794-3f53-40c4-a5dc-77c475a8561d'
+  --header 'Host: papinet.road.papinet.io' \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 If all goes well, the company **Fast** will receive a response like this:
@@ -307,7 +334,7 @@ The step 6 of the scenario A will simulate the situation in which the company **
 ```text
 $ curl --request GET \
   --URL https://papinet.road.papinet.io/shipments/c51d8903-01d1-485c-96ce-51a9be192207 \
-  --header 'Authorization: Bearer efe30794-3f53-40c4-a5dc-77c475a8561d'
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 or, if you use locally the docker container of the papiNet mock server:
@@ -315,8 +342,8 @@ or, if you use locally the docker container of the papiNet mock server:
 ```text
 $ curl --request GET \
   --URL http://localhost:3001/shipments/c51d8903-01d1-485c-96ce-51a9be192207 \
-  --header 'X-papiNet-Domain: papinet.road.papinet.io' \
-  --header 'Authorization: Bearer efe30794-3f53-40c4-a5dc-77c475a8561d'
+  --header 'Host: papinet.road.papinet.io' \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 If all goes well, the company **Fast** will receive a response like this:
@@ -358,7 +385,7 @@ The step 7 of the scenario A will simulate the situation in which the company **
 ```text
 $ curl --request GET \
   --URL https://papinet.road.papinet.io/shipments/c51d8903-01d1-485c-96ce-51a9be192207 \
-  --header 'Authorization: Bearer efe30794-3f53-40c4-a5dc-77c475a8561d'
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 or, if you use locally the docker container of the papiNet mock server:
@@ -366,8 +393,8 @@ or, if you use locally the docker container of the papiNet mock server:
 ```text
 $ curl --request GET \
   --URL http://localhost:3001/shipments/c51d8903-01d1-485c-96ce-51a9be192207 \
-  --header 'X-papiNet-Domain: papinet.road.papinet.io' \
-  --header 'Authorization: Bearer efe30794-3f53-40c4-a5dc-77c475a8561d'
+  --header 'Host: papinet.road.papinet.io' \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 If all goes well, the company **Fast** will receive a response like this:
@@ -410,8 +437,8 @@ The company **Pulp**, being a _Supplier_, sends an API request to the company **
 
 ```text
 $ curl --request POST \
-  --URL https://papinet.fast.papinet.io/token \
-  --user 'public-36297346:private-ce2d3cf4'
+  --URL https://papinet.fast.papinet.io/tokens \
+  --user 'public-36297346:private-ce2d3cf4' \
   --header 'Content-Type: application/x-www-form-urlencoded' \
   --data 'grant_type=client_credentials'
 ```
@@ -421,7 +448,7 @@ or, if you use locally the docker container of the papiNet mock server:
 ```text
 $ curl --request POST \
   --URL http://localhost:3001/tokens \
-  --header 'X-papiNet-Domain: papinet.fast.papinet.io' \
+  --header 'Host: papinet.fast.papinet.io' \
   --user 'public-36297346:private-ce2d3cf4' \
   --header 'Content-Type: application/x-www-form-urlencoded' \
   --data 'grant_type=client_credentials'
@@ -437,6 +464,33 @@ If all goes well, the company **Pulp** will receive a response like this:
 }
 ```
 
+In order to re-use the value of the `access_token` in subsequent API requests, it is convenient to save it into an environment variable:
+
+```text
+$ export ACCESS_TOKEN=$(curl --request POST \
+  --URL https://papinet.fast.papinet.io/tokens \
+  --user 'public-36297346:private-ce2d3cf4' \
+  --header 'Content-Type: application/x-www-form-urlencoded' \
+  --data 'grant_type=client_credentials' | jq -r '.access_token')
+```
+
+or, if you use locally the docker container of the papiNet mock server:
+
+```$ export ACCESS_TOKEN=$(curl --request POST \
+  --URL http://localhost:3001/tokens \
+  --header 'Host: papinet.fast.papinet.io' \
+  --user 'public-36297346:private-ce2d3cf4' \
+  --header 'Content-Type: application/x-www-form-urlencoded' \
+  --data 'grant_type=client_credentials' | jq -r '.access_token')
+```
+
+You can easily verify the value of the `ACCESS_TOKEN` environment variable using:
+
+```text
+$ echo $ACCESS_TOKEN
+e7e32320-7ec4-4d94-ba30-dfdaae6ef686
+```
+
 #### Step 2 of Scenario B - List of Shipments
 
 The company **Pulp**, being a _Supplier_, sends an API request to the company **Fast**, being a _Forwarder_, in order to get the list of all its _Active shipments_:
@@ -444,7 +498,7 @@ The company **Pulp**, being a _Supplier_, sends an API request to the company **
 ```text
 $ curl --request GET \
   --URL https://papinet.fast.papinet.io/shipments?shipmentStatus=Active \
-  --header 'Authorization: Bearer 1d3c4294-4624-4cec-a769-fa345c8235bc'
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 or, if you use locally the docker container of the papiNet mock server:
@@ -452,8 +506,8 @@ or, if you use locally the docker container of the papiNet mock server:
 ```text
 $ curl --request GET \
   --URL http://localhost:3001/shipments?shipmentStatus=Active \
-  --header 'X-papiNet-Domain: papinet.fast.papinet.io' \
-  --header 'Authorization: Bearer 1d3c4294-4624-4cec-a769-fa345c8235bc'
+  --header 'Host: papinet.fast.papinet.io' \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 If all goes well, the company **Pulp** will receive a response like this:
@@ -524,7 +578,7 @@ The company **Pulp**, being a _Supplier_, sends an API request to the company **
 ```text
 $ curl --request GET \
   --URL https://papinet.fast.papinet.io/shipments/3a9108d5-f7f0-42ae-9a29-eb302bdb8ede \
-  --header 'Authorization: Bearer 1d3c4294-4624-4cec-a769-fa345c8235bc'
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 or, if you use locally the docker container of the papiNet mock server:
@@ -532,8 +586,8 @@ or, if you use locally the docker container of the papiNet mock server:
 ```text
 $ curl --request GET \
   --URL http://localhost:3001/shipments/3a9108d5-f7f0-42ae-9a29-eb302bdb8ede \
-  --header 'X-papiNet-Domain: papinet.fast.papinet.io' \
-  --header 'Authorization: Bearer 1d3c4294-4624-4cec-a769-fa345c8235bc'
+  --header 'Host: papinet.fast.papinet.io' \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 If all goes well, the company **Pulp** will receive a response like this:
@@ -578,7 +632,7 @@ The step 4 of the scenario B will simulate the situation in which the company **
 ```text
 $ curl --request GET \
   --URL https://papinet.fast.papinet.io/shipments/3a9108d5-f7f0-42ae-9a29-eb302bdb8ede \
-  --header 'Authorization: Bearer 1d3c4294-4624-4cec-a769-fa345c8235bc'
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 or, if you use locally the docker container of the papiNet mock server:
@@ -586,8 +640,8 @@ or, if you use locally the docker container of the papiNet mock server:
 ```text
 $ curl --request GET \
   --URL http://localhost:3001/shipments/3a9108d5-f7f0-42ae-9a29-eb302bdb8ede \
-  --header 'X-papiNet-Domain: papinet.fast.papinet.io' \
-  --header 'Authorization: Bearer 1d3c4294-4624-4cec-a769-fa345c8235bc'
+  --header 'Host: papinet.fast.papinet.io' \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 If all goes well, the company **Pulp** will receive a response like this:
@@ -632,7 +686,7 @@ The step 5 of the scenario B will simulate the situation in which the company **
 ```text
 $ curl --request GET \
   --URL https://papinet.fast.papinet.io/shipments/3a9108d5-f7f0-42ae-9a29-eb302bdb8ede \
-  --header 'Authorization: Bearer 1d3c4294-4624-4cec-a769-fa345c8235bc'
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 or, if you use locally the docker container of the papiNet mock server:
@@ -640,8 +694,8 @@ or, if you use locally the docker container of the papiNet mock server:
 ```text
 $ curl --request GET \
   --URL http://localhost:3001/shipments/3a9108d5-f7f0-42ae-9a29-eb302bdb8ede \
-  --header 'X-papiNet-Domain: papinet.fast.papinet.io' \
-  --header 'Authorization: Bearer 1d3c4294-4624-4cec-a769-fa345c8235bc'
+  --header 'Host: papinet.fast.papinet.io' \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 If all goes well, the company **Pulp** will receive a response like this:
@@ -686,7 +740,7 @@ The step 6 of the scenario B will simulate the situation in which the company **
 ```text
 $ curl --request GET \
   --URL https://papinet.fast.papinet.io/shipments/3a9108d5-f7f0-42ae-9a29-eb302bdb8ede \
-  --header 'Authorization: Bearer 1d3c4294-4624-4cec-a769-fa345c8235bc'
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 or, if you use locally the docker container of the papiNet mock server:
@@ -694,8 +748,8 @@ or, if you use locally the docker container of the papiNet mock server:
 ```text
 $ curl --request GET \
   --URL http://localhost:3001/shipments/3a9108d5-f7f0-42ae-9a29-eb302bdb8ede \
-  --header 'X-papiNet-Domain: papinet.fast.papinet.io' \
-  --header 'Authorization: Bearer 1d3c4294-4624-4cec-a769-fa345c8235bc'
+  --header 'Host: papinet.fast.papinet.io' \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 If all goes well, the company **Pulp** will receive a response like this:
@@ -740,7 +794,7 @@ The step 7 of the scenario B will simulate the situation in which the company **
 ```text
 $ curl --request GET \
   --URL https://papinet.fast.papinet.io/shipments/3a9108d5-f7f0-42ae-9a29-eb302bdb8ede \
-  --header 'Authorization: Bearer 1d3c4294-4624-4cec-a769-fa345c8235bc'
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 or, if you use locally the docker container of the papiNet mock server:
@@ -748,8 +802,8 @@ or, if you use locally the docker container of the papiNet mock server:
 ```text
 $ curl --request GET \
   --URL http://localhost:3001/shipments/3a9108d5-f7f0-42ae-9a29-eb302bdb8ede \
-  --header 'X-papiNet-Domain: papinet.fast.papinet.io' \
-  --header 'Authorization: Bearer 1d3c4294-4624-4cec-a769-fa345c8235bc'
+  --header 'Host: papinet.fast.papinet.io' \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 If all goes well, the company **Pulp** will receive a response like this:
@@ -808,7 +862,7 @@ or, if you use locally the docker container of the papiNet mock server:
 ```text
 $ curl --request POST \
   --URL http://localhost:3001/tokens \
-  --header 'X-papiNet-Domain: papinet.pulp.papinet.io' \
+  --header 'Host: papinet.pulp.papinet.io' \
   --user 'public-36297346:private-ce2d3cf4' \
   --header 'Content-Type: application/x-www-form-urlencoded' \
   --data 'grant_type=client_credentials'
@@ -824,6 +878,33 @@ If all goes well, the company **Corp** will receive a response like this:
 }
 ```
 
+In order to re-use the value of the `access_token` in subsequent API requests, it is convenient to save it into an environment variable:
+
+```text
+$ export ACCESS_TOKEN=$(curl --request POST \
+  --URL https://papinet.pulp.papinet.io/tokens \
+  --user 'public-36297346:private-ce2d3cf4' \
+  --header 'Content-Type: application/x-www-form-urlencoded' \
+  --data 'grant_type=client_credentials' | jq -r '.access_token')
+```
+
+or, if you use locally the docker container of the papiNet mock server:
+
+```$ export ACCESS_TOKEN=$(curl --request POST \
+  --URL http://localhost:3001/tokens \
+  --header 'Host: papinet.pulp.papinet.io' \
+  --user 'public-36297346:private-ce2d3cf4' \
+  --header 'Content-Type: application/x-www-form-urlencoded' \
+  --data 'grant_type=client_credentials' | jq -r '.access_token')
+```
+
+You can easily verify the value of the `ACCESS_TOKEN` environment variable using:
+
+```text
+$ echo $ACCESS_TOKEN
+4da15489-edd6-434e-96fe-830fc8beba2d
+```
+
 #### Step 2 of Scenario C - List of Shipments
 
 The company **Corp**, being both an _End User_ and an _Order Issuer_, sends an API request to the company **Pulp**, being a _Supplier_, in order to get the list of all its _Active shipments_:
@@ -831,7 +912,7 @@ The company **Corp**, being both an _End User_ and an _Order Issuer_, sends an A
 ```text
 $ curl --request GET \
   --URL https://papinet.pulp.papinet.io/shipments?shipmentStatus=Active \
-  --header 'Authorization: Bearer fe69f78b-a2fd-4e8d-99c1-2f9672846a9a'
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 or, if you use locally the docker container of the papiNet mock server:
@@ -839,8 +920,8 @@ or, if you use locally the docker container of the papiNet mock server:
 ```text
 $ curl --request GET \
   --URL http://localhost:3001/shipments?shipmentStatus=Active \
-  --header 'X-papiNet-Domain: papinet.pulp.papinet.io' \
-  --header 'Authorization: Bearer fe69f78b-a2fd-4e8d-99c1-2f9672846a9a'
+  --header 'Host: papinet.pulp.papinet.io' \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 If all goes well, the company **Corp** will receive a response like this:
@@ -911,7 +992,7 @@ The company **Corp**, being both an _End User_ and an _Order Issuer_, sends an A
 ```text
 $ curl --request GET \
   --URL https://papinet.pulp.papinet.io/shipments/d4fd1f2c-642f-4df8-a7b3-139cf9d63d17 \
-  --header 'Authorization: Bearer fe69f78b-a2fd-4e8d-99c1-2f9672846a9a'
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 or, if you use locally the docker container of the papiNet mock server:
@@ -919,8 +1000,8 @@ or, if you use locally the docker container of the papiNet mock server:
 ```text
 $ curl --request GET \
   --URL http://localhost:3001/shipments/d4fd1f2c-642f-4df8-a7b3-139cf9d63d17 \
-  --header 'X-papiNet-Domain: papinet.pulp.papinet.io' \
-  --header 'Authorization: Bearer fe69f78b-a2fd-4e8d-99c1-2f9672846a9a'
+  --header 'Host: papinet.pulp.papinet.io' \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 If all goes well, the company **Corp** will receive a response like this:
@@ -965,7 +1046,7 @@ The step 4 of the scenario C will simulate the situation in which the company **
 ```text
 $ curl --request GET \
   --URL https://papinet.pulp.papinet.io/shipments/d4fd1f2c-642f-4df8-a7b3-139cf9d63d17 \
-  --header 'Authorization: Bearer fe69f78b-a2fd-4e8d-99c1-2f9672846a9a'
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 or, if you use locally the docker container of the papiNet mock server:
@@ -973,8 +1054,8 @@ or, if you use locally the docker container of the papiNet mock server:
 ```text
 $ curl --request GET \
   --URL http://localhost:3001/shipments/d4fd1f2c-642f-4df8-a7b3-139cf9d63d17 \
-  --header 'X-papiNet-Domain: papinet.pulp.papinet.io' \
-  --header 'Authorization: Bearer fe69f78b-a2fd-4e8d-99c1-2f9672846a9a'
+  --header 'Host: papinet.pulp.papinet.io' \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 If all goes well, the company **Corp** will receive a response like this:
@@ -1019,7 +1100,7 @@ The step 5 of the scenario C will simulate the situation in which the company **
 ```text
 $ curl --request GET \
   --URL https://papinet.pulp.papinet.io/shipments/d4fd1f2c-642f-4df8-a7b3-139cf9d63d17 \
-  --header 'Authorization: Bearer fe69f78b-a2fd-4e8d-99c1-2f9672846a9a'
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 or, if you use locally the docker container of the papiNet mock server:
@@ -1027,8 +1108,8 @@ or, if you use locally the docker container of the papiNet mock server:
 ```text
 $ curl --request GET \
   --URL http://localhost:3001/shipments/d4fd1f2c-642f-4df8-a7b3-139cf9d63d17 \
-  --header 'X-papiNet-Domain: papinet.pulp.papinet.io' \
-  --header 'Authorization: Bearer fe69f78b-a2fd-4e8d-99c1-2f9672846a9a'
+  --header 'Host: papinet.pulp.papinet.io' \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 If all goes well, the company **Corp** will receive a response like this:
@@ -1073,7 +1154,7 @@ The step 6 of the scenario C will simulate the situation in which the company **
 ```text
 $ curl --request GET \
   --URL https://papinet.pulp.papinet.io/shipments/d4fd1f2c-642f-4df8-a7b3-139cf9d63d17 \
-  --header 'Authorization: Bearer fe69f78b-a2fd-4e8d-99c1-2f9672846a9a'
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 or, if you use locally the docker container of the papiNet mock server:
@@ -1081,8 +1162,8 @@ or, if you use locally the docker container of the papiNet mock server:
 ```text
 $ curl --request GET \
   --URL http://localhost:3001/shipments/d4fd1f2c-642f-4df8-a7b3-139cf9d63d17 \
-  --header 'X-papiNet-Domain: papinet.pulp.papinet.io' \
-  --header 'Authorization: Bearer fe69f78b-a2fd-4e8d-99c1-2f9672846a9a'
+  --header 'Host: papinet.pulp.papinet.io' \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 If all goes well, the company **Corp** will receive a response like this:
@@ -1127,7 +1208,7 @@ The step 7 of the scenario C will simulate the situation in which the company **
 ```text
 $ curl --request GET \
   --URL https://papinet.pulp.papinet.io/shipments/d4fd1f2c-642f-4df8-a7b3-139cf9d63d17 \
-  --header 'Authorization: Bearer fe69f78b-a2fd-4e8d-99c1-2f9672846a9a'
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 or, if you use locally the docker container of the papiNet mock server:
@@ -1135,8 +1216,8 @@ or, if you use locally the docker container of the papiNet mock server:
 ```text
 $ curl --request GET \
   --URL http://localhost:3001/shipments/d4fd1f2c-642f-4df8-a7b3-139cf9d63d17 \
-  --header 'X-papiNet-Domain: papinet.pulp.papinet.io' \
-  --header 'Authorization: Bearer fe69f78b-a2fd-4e8d-99c1-2f9672846a9a'
+  --header 'Host: papinet.pulp.papinet.io' \
+  --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
 
 If all goes well, the company **Corp** will receive a response like this:

--- a/1.1.0/shipment-status.md
+++ b/1.1.0/shipment-status.md
@@ -63,7 +63,7 @@ or, if you use locally the docker container of the papiNet mock server:
 
 ```text
 $ curl --request POST \
-  --URL http://localhost:3001/tokens \
+  --URL http://localhost:3002/tokens \
   --header 'Host: papinet.road.papinet.io' \
   --user 'public-36297346:private-ce2d3cf4' \
   --header 'Content-Type: application/x-www-form-urlencoded' \
@@ -93,7 +93,7 @@ $ export ACCESS_TOKEN=$(curl --request POST \
 or, if you use locally the docker container of the papiNet mock server:
 
 ```$ export ACCESS_TOKEN=$(curl --request POST \
-  --URL http://localhost:3001/tokens \
+  --URL http://localhost:3002/tokens \
   --header 'Host: papinet.road.papinet.io' \
   --user 'public-36297346:private-ce2d3cf4' \
   --header 'Content-Type: application/x-www-form-urlencoded' \
@@ -121,7 +121,7 @@ or, if you use locally the docker container of the papiNet mock server:
 
 ```text
 $ curl --request GET \
-  --URL http://localhost:3001/shipments?shipmentStatus=Active \
+  --URL http://localhost:3002/shipments?shipmentStatus=Active \
   --header 'Host: papinet.road.papinet.io' \
   --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
@@ -194,7 +194,7 @@ or, if you use locally the docker container of the papiNet mock server:
 
 ```text
 $ curl --request GET \
-  --URL http://localhost:3001/shipments/c51d8903-01d1-485c-96ce-51a9be192207 \
+  --URL http://localhost:3002/shipments/c51d8903-01d1-485c-96ce-51a9be192207 \
   --header 'Host: papinet.road.papinet.io' \
   --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
@@ -243,7 +243,7 @@ or, if you use locally the docker container of the papiNet mock server:
 
 ```text
 $ curl --request GET \
-  --URL http://localhost:3001/shipments/c51d8903-01d1-485c-96ce-51a9be192207 \
+  --URL http://localhost:3002/shipments/c51d8903-01d1-485c-96ce-51a9be192207 \
   --header 'Host: papinet.road.papinet.io' \
   --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
@@ -292,7 +292,7 @@ or, if you use locally the docker container of the papiNet mock server:
 
 ```text
 $ curl --request GET \
-  --URL http://localhost:3001/shipments/c51d8903-01d1-485c-96ce-51a9be192207 \
+  --URL http://localhost:3002/shipments/c51d8903-01d1-485c-96ce-51a9be192207 \
   --header 'Host: papinet.road.papinet.io' \
   --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
@@ -341,7 +341,7 @@ or, if you use locally the docker container of the papiNet mock server:
 
 ```text
 $ curl --request GET \
-  --URL http://localhost:3001/shipments/c51d8903-01d1-485c-96ce-51a9be192207 \
+  --URL http://localhost:3002/shipments/c51d8903-01d1-485c-96ce-51a9be192207 \
   --header 'Host: papinet.road.papinet.io' \
   --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
@@ -392,7 +392,7 @@ or, if you use locally the docker container of the papiNet mock server:
 
 ```text
 $ curl --request GET \
-  --URL http://localhost:3001/shipments/c51d8903-01d1-485c-96ce-51a9be192207 \
+  --URL http://localhost:3002/shipments/c51d8903-01d1-485c-96ce-51a9be192207 \
   --header 'Host: papinet.road.papinet.io' \
   --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
@@ -447,7 +447,7 @@ or, if you use locally the docker container of the papiNet mock server:
 
 ```text
 $ curl --request POST \
-  --URL http://localhost:3001/tokens \
+  --URL http://localhost:3002/tokens \
   --header 'Host: papinet.fast.papinet.io' \
   --user 'public-36297346:private-ce2d3cf4' \
   --header 'Content-Type: application/x-www-form-urlencoded' \
@@ -477,7 +477,7 @@ $ export ACCESS_TOKEN=$(curl --request POST \
 or, if you use locally the docker container of the papiNet mock server:
 
 ```$ export ACCESS_TOKEN=$(curl --request POST \
-  --URL http://localhost:3001/tokens \
+  --URL http://localhost:3002/tokens \
   --header 'Host: papinet.fast.papinet.io' \
   --user 'public-36297346:private-ce2d3cf4' \
   --header 'Content-Type: application/x-www-form-urlencoded' \
@@ -505,7 +505,7 @@ or, if you use locally the docker container of the papiNet mock server:
 
 ```text
 $ curl --request GET \
-  --URL http://localhost:3001/shipments?shipmentStatus=Active \
+  --URL http://localhost:3002/shipments?shipmentStatus=Active \
   --header 'Host: papinet.fast.papinet.io' \
   --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
@@ -585,7 +585,7 @@ or, if you use locally the docker container of the papiNet mock server:
 
 ```text
 $ curl --request GET \
-  --URL http://localhost:3001/shipments/3a9108d5-f7f0-42ae-9a29-eb302bdb8ede \
+  --URL http://localhost:3002/shipments/3a9108d5-f7f0-42ae-9a29-eb302bdb8ede \
   --header 'Host: papinet.fast.papinet.io' \
   --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
@@ -639,7 +639,7 @@ or, if you use locally the docker container of the papiNet mock server:
 
 ```text
 $ curl --request GET \
-  --URL http://localhost:3001/shipments/3a9108d5-f7f0-42ae-9a29-eb302bdb8ede \
+  --URL http://localhost:3002/shipments/3a9108d5-f7f0-42ae-9a29-eb302bdb8ede \
   --header 'Host: papinet.fast.papinet.io' \
   --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
@@ -693,7 +693,7 @@ or, if you use locally the docker container of the papiNet mock server:
 
 ```text
 $ curl --request GET \
-  --URL http://localhost:3001/shipments/3a9108d5-f7f0-42ae-9a29-eb302bdb8ede \
+  --URL http://localhost:3002/shipments/3a9108d5-f7f0-42ae-9a29-eb302bdb8ede \
   --header 'Host: papinet.fast.papinet.io' \
   --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
@@ -747,7 +747,7 @@ or, if you use locally the docker container of the papiNet mock server:
 
 ```text
 $ curl --request GET \
-  --URL http://localhost:3001/shipments/3a9108d5-f7f0-42ae-9a29-eb302bdb8ede \
+  --URL http://localhost:3002/shipments/3a9108d5-f7f0-42ae-9a29-eb302bdb8ede \
   --header 'Host: papinet.fast.papinet.io' \
   --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
@@ -801,7 +801,7 @@ or, if you use locally the docker container of the papiNet mock server:
 
 ```text
 $ curl --request GET \
-  --URL http://localhost:3001/shipments/3a9108d5-f7f0-42ae-9a29-eb302bdb8ede \
+  --URL http://localhost:3002/shipments/3a9108d5-f7f0-42ae-9a29-eb302bdb8ede \
   --header 'Host: papinet.fast.papinet.io' \
   --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
@@ -861,7 +861,7 @@ or, if you use locally the docker container of the papiNet mock server:
 
 ```text
 $ curl --request POST \
-  --URL http://localhost:3001/tokens \
+  --URL http://localhost:3002/tokens \
   --header 'Host: papinet.pulp.papinet.io' \
   --user 'public-36297346:private-ce2d3cf4' \
   --header 'Content-Type: application/x-www-form-urlencoded' \
@@ -891,7 +891,7 @@ $ export ACCESS_TOKEN=$(curl --request POST \
 or, if you use locally the docker container of the papiNet mock server:
 
 ```$ export ACCESS_TOKEN=$(curl --request POST \
-  --URL http://localhost:3001/tokens \
+  --URL http://localhost:3002/tokens \
   --header 'Host: papinet.pulp.papinet.io' \
   --user 'public-36297346:private-ce2d3cf4' \
   --header 'Content-Type: application/x-www-form-urlencoded' \
@@ -919,7 +919,7 @@ or, if you use locally the docker container of the papiNet mock server:
 
 ```text
 $ curl --request GET \
-  --URL http://localhost:3001/shipments?shipmentStatus=Active \
+  --URL http://localhost:3002/shipments?shipmentStatus=Active \
   --header 'Host: papinet.pulp.papinet.io' \
   --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
@@ -999,7 +999,7 @@ or, if you use locally the docker container of the papiNet mock server:
 
 ```text
 $ curl --request GET \
-  --URL http://localhost:3001/shipments/d4fd1f2c-642f-4df8-a7b3-139cf9d63d17 \
+  --URL http://localhost:3002/shipments/d4fd1f2c-642f-4df8-a7b3-139cf9d63d17 \
   --header 'Host: papinet.pulp.papinet.io' \
   --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
@@ -1053,7 +1053,7 @@ or, if you use locally the docker container of the papiNet mock server:
 
 ```text
 $ curl --request GET \
-  --URL http://localhost:3001/shipments/d4fd1f2c-642f-4df8-a7b3-139cf9d63d17 \
+  --URL http://localhost:3002/shipments/d4fd1f2c-642f-4df8-a7b3-139cf9d63d17 \
   --header 'Host: papinet.pulp.papinet.io' \
   --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
@@ -1107,7 +1107,7 @@ or, if you use locally the docker container of the papiNet mock server:
 
 ```text
 $ curl --request GET \
-  --URL http://localhost:3001/shipments/d4fd1f2c-642f-4df8-a7b3-139cf9d63d17 \
+  --URL http://localhost:3002/shipments/d4fd1f2c-642f-4df8-a7b3-139cf9d63d17 \
   --header 'Host: papinet.pulp.papinet.io' \
   --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
@@ -1161,7 +1161,7 @@ or, if you use locally the docker container of the papiNet mock server:
 
 ```text
 $ curl --request GET \
-  --URL http://localhost:3001/shipments/d4fd1f2c-642f-4df8-a7b3-139cf9d63d17 \
+  --URL http://localhost:3002/shipments/d4fd1f2c-642f-4df8-a7b3-139cf9d63d17 \
   --header 'Host: papinet.pulp.papinet.io' \
   --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```
@@ -1215,7 +1215,7 @@ or, if you use locally the docker container of the papiNet mock server:
 
 ```text
 $ curl --request GET \
-  --URL http://localhost:3001/shipments/d4fd1f2c-642f-4df8-a7b3-139cf9d63d17 \
+  --URL http://localhost:3002/shipments/d4fd1f2c-642f-4df8-a7b3-139cf9d63d17 \
   --header 'Host: papinet.pulp.papinet.io' \
   --header 'Authorization: Bearer '$ACCESS_TOKEN
 ```


### PR DESCRIPTION
The new papiNet mock server is already deployed and running at
* https://papinet.papinet.io/
* https://papinet.road.papinet.io/
* https://papinet.fast.papinet.io/
* https://papinet.pulp.papinet.io/

so the `curl` commands within both the _Order Status_ and _Shipment Status_ use case documents are working.